### PR TITLE
Adding Roles & Placeholders schemas

### DIFF
--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -26,7 +26,9 @@ ENDPOINTS = [
     "clients",
     "milestones",
     "people",
-    "projects"
+    "projects",
+    "placeholders",
+    "roles"
 ]
 
 PRIMARY_KEY = "id"

--- a/tap_harvest_forecast/schemas/placeholders.json
+++ b/tap_harvest_forecast/schemas/placeholders.json
@@ -1,0 +1,44 @@
+{
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "archived": {
+        "type": [
+          "null",
+          "boolean"
+        ]
+      },
+      "updated_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
+      "updated_by_id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "roles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+  

--- a/tap_harvest_forecast/schemas/roles.json
+++ b/tap_harvest_forecast/schemas/roles.json
@@ -1,0 +1,37 @@
+{
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "name": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "harvest_role_id": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "person_ids": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      },
+      "placeholder_ids": {
+        "type": "array",
+        "items": {
+          "type": "integer"
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+  


### PR DESCRIPTION
Hi Singer Team.

Adding in two new schema's for Harvets Forecast.
Schemas:
Roles
Placeholders

They've been added into the endpoints array within init.py

Should allow for extraction of that data via the API endpoint(s).
The schemas have been validated against the endpoints via curls and local deployment of the tap.