### PR TITLE
version bump v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
+## 1.1.2
+  *  Bug fix in `sync_endpoints` [#21](https://github.com/singer-io/tap-harvest-forecast/pull/21)
 
-## [v1.1.1](https://github.com/singer-io/tap-harvest-forecast/tree/v1.1.1) (2021-04-19)
+## [1.1.1](https://github.com/singer-io/tap-harvest-forecast/tree/v1.1.1) (2021-04-19)
 
 [Full Changelog](https://github.com/singer-io/tap-harvest-forecast/compare/v1.1.0...v1.1.1)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-harvest-forecast',
-      version="1.1.1",
+      version="1.1.2",
       description='Singer.io tap for extracting data from the Harvest Forecast api',
       author='Robert Benjamin',
       url='https://github.com/singer-io/tap-harvest-forecast',


### PR DESCRIPTION
# Description of change
## 1.1.2
  *  Bug fix in `sync_endpoints` [#21](https://github.com/singer-io/tap-harvest-forecast/pull/21)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
