### PR TITLE
1.1.3: Fixes to get tap running again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+
+## 1.1.3
+  * Bug fixes to get the tap running again successfully [#24](https://github.com/singer-io/tap-harvest-forecast/pull/24)
+    * Reverted change to how replication keys are assigned to fix KeyError
+    * Removed incomplete activate_version feature that was accidentally included
+
 ## 1.1.2
   *  Bug fix in `sync_endpoints` [#21](https://github.com/singer-io/tap-harvest-forecast/pull/21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.3
   * Bug fixes to get the tap running again successfully [#24](https://github.com/singer-io/tap-harvest-forecast/pull/24)
-    * Reverted change to how replication keys are assigned to fix KeyError
+    * Reverted change to how replication keys are assigned to fix AttributeError
     * Removed incomplete activate_version feature that was accidentally included
 
 ## 1.1.2

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-harvest-forecast',
-      version="1.1.2",
+      version="1.1.3",
       description='Singer.io tap for extracting data from the Harvest Forecast api',
       author='Robert Benjamin',
       url='https://github.com/singer-io/tap-harvest-forecast',

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -136,9 +136,6 @@ def request(url, params = None):
     return resp.json()
 
 
-def get_stream_version(tap_stream_id):
-    return int(time.time() * 1000)
-
 def append_times_to_dates(item, date_fields):
     if date_fields:
         for date_field in date_fields:
@@ -165,12 +162,6 @@ def sync_endpoint(catalog_entry, schema, mdata, date_fields = None):
 
     time_extracted = utils.now()
 
-    stream_version = get_stream_version(catalog_entry.tap_stream_id)
-    activate_version_message = singer.ActivateVersionMessage(
-        stream=catalog_entry.stream,
-        version=stream_version
-    )
-
     url = get_url(catalog_entry.tap_stream_id)
     start = utils.strptime_to_utc(get_start(catalog_entry.tap_stream_id))
     end = utils.strptime_to_utc(get_end(catalog_entry.tap_stream_id))
@@ -196,7 +187,6 @@ def sync_endpoint(catalog_entry, schema, mdata, date_fields = None):
                     new_record = singer.RecordMessage(
                         stream=catalog_entry.stream,
                         record=rec,
-                        version=stream_version,
                         time_extracted=time_extracted)
                     singer.write_message(new_record)
 
@@ -204,11 +194,9 @@ def sync_endpoint(catalog_entry, schema, mdata, date_fields = None):
 
 
     singer.write_state(STATE)
-    singer.write_message(activate_version_message)
 
 def do_sync(catalog):
     LOGGER.info("Starting sync")
-
     for stream in catalog.streams:
         mdata = metadata.to_map(stream.metadata)
         is_selected = metadata.get(mdata, (), 'selected')

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -225,7 +225,7 @@ def do_discover():
         mdata = metadata.new()
 
         mdata = metadata.write(mdata, (), 'table-key-properties', [PRIMARY_KEY])
-        mdata = metadata.write(mdata, (), 'valid-replication-keys', schema.replication_keys)
+        mdata = metadata.write(mdata, (), 'valid-replication-keys', [REPLICATION_KEY])
 
         for field_name in schema['properties'].keys():
             if field_name == PRIMARY_KEY or field_name == REPLICATION_KEY:


### PR DESCRIPTION
# Description of change
Attempting to get this thing running again. At least out of the box, there were only two glaring issues.

I'm not sure if there are any other problems, but without being able to even run the tap, there's no way to tell. This PR does two things:

1. Reverts the bug introduced in a previous commit that caused discovery mode to fail but looking for the key `replication_keys` on a JSON Schema dictionary. The replication key for all streams should be `updated_at` according to the previous code.
2. Reverts the accidental inclusion of the activate_version message usages, since it was incompletely implemented. This is a very tricky feature, and I would not recommend its usage. Beyond that, and without getting into too much of the nitty gritty, the tap is saving and using a bookmark, indicating that every stream is incrementally extracted. This is incompatible with the concept of activate_version messages, since those are used to track a distinct "version" of a _**full set of data**_ for the target, and as such only make sense with "full table" extraction modes.

Manually running the tap with all tables and fields selected multiple times with a contrived free-trial account indicates that each stream was able to incrementally extract data with the exception of roles (which, inspecting the state output from the first run appears to not have an `updated_at` value, and so this one is implicitly full table as written).

# Manual QA steps
 - Ran through the tap multiple times using the state from the previous and confirmed state usage behavior, validation of JSON Schema, and general requests for each stream
 
# Risks
 - Zero, this is 100% broken right now
 
# Rollback steps
 - revert this branch, bump patch version
