### PR TITLE
Update OAuth instructions to use curl to get refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ Author: Robert Benjamin ([@robertbenjamin](https://github.com/robertbenjamin))
     Visit the [developer tools](https://id.getharvest.com/developers) page on
     Harvest's website and create a new oauth token
 
-    Paste the Client ID you got from the above page in the url of a browser like
-    `https://id.getharvest.com/oauth2/authorize?client_id={OAUTH_CLIENT_ID}&response_type=code`. Now you're
-    able to login, click 'authorize app' and then are redirected to a url like
-    this
-    `https://id.getharvest.com/oauth2/authorize?code={OAUTH_REFRESH_TOKEN}&scope=all`.
-    You will use this `OAUTH_REFRESH_TOKEN` in the following step to configure
-    the oauth application
+    
+    Paste the Client ID you got from the above page in the url of a browser like `https://id.getharvest.com/oauth2/authorize?client_id={OAUTH_CLIENT_ID}&response_type=code`. Now you're able to login, click 'authorize app' and then are redirected to a url like this `https://id.getharvest.com/oauth2/authorize?code={AUTHORIZATION_CODE}&scope=forecast%3A{ACCOUNT_ID}`. Use the ACCOUNT_ID for the account_id setting. Copy the AUTHORIZATION_CODE into this curl command to get the REFRESH_TOKEN for the refresh_token setting:
+   ```
+   curl -X POST \
+   -H "User-Agent: MyApp (yourname@example.com)" \
+   -d "code=$AUTHORIZATION_CODE" \
+   -d "client_id=$CLIENT_ID" \
+   -d "client_secret=$CLIENT_SECRET" \
+   -d "grant_type=authorization_code" \
+   'https://id.getharvest.com/api/v2/oauth2/token'
+   ```
 
 3. Create your tap's `tap_config.json` file which should look like the following:
 


### PR DESCRIPTION
# Description of change
The current instructions are incorrect. The code received in the redirect url is not a refresh token, and the tap fails when it tries to use it as one. In order to get a refresh token, there is a code exchange step. The easiest way to do this is using curl, so I've  added this step to the instructions.

This is based on Harvest's documentation: https://help.getharvest.com/api-v2/authentication-api/authentication/authentication/#oauth2-authorization-flow

# Manual QA steps
 - Follow the instructions, verify they work.
 
# Risks
 - Just a README change, risk is misinformation
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
