### PR TITLE
Update libraries and add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-harvest-forecast
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-harvest-forecast
             source /usr/local/share/virtualenvs/tap-harvest-forecast/bin/activate
             uv pip install -U pip setuptools
             uv pip install .[dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,11 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_harvest_forecast/schemas/*.json
+      - run:
+          name: 'Unit Tests + Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-harvest-forecast/bin/activate
+            python -m unittest discover -s tests -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,56 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             stitch-validate-json tap_harvest_forecast/schemas/*.json
       - run:
-          name: 'Unit Tests + Integration Tests'
+          name: "pylint"
           command: |
             source /usr/local/share/virtualenvs/tap-harvest-forecast/bin/activate
-            python -m unittest discover -s tests -v
+            uv pip install pylint
+            pylint tap_harvest_forecast -d C,R,W
+      - run:
+          name: "Unit Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-harvest-forecast/bin/activate
+            uv pip install pytest coverage
+            coverage run -m pytest tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
+          name: "Mock Integration Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-harvest-forecast/bin/activate
+            uv pip install pytest
+            python -m pytest tests/mock_integration/ -v
+      - run:
+          name: "Integration Tests"
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            uv pip install --upgrade awscli
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            unset USE_STITCH_BACKEND
+            # Temporarily move mock_integration out of the tests/ tree so that
+            # run-test does not discover it
+            mv tests/mock_integration /tmp/mock_integration_backup
+            run-test --tap=tap-harvest-forecast tests
+            mv /tmp/mock_integration_backup tests/mock_integration
 
 workflows:
   version: 2
   commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 19 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - build:
           context: circleci-user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+  * Upgrade `singer-python`, `requests` and `backoff` to latest version
+  * Add unit tests and mocked integration tests [#32](https://github.com/singer-io/tap-harvest-forecast/pull/32)
+
 ## 1.1.5
   * Bump dependencies for compliance [#31](https://github.com/singer-io/tap-harvest-forecast/pull/31)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(name='tap-harvest-forecast',
       version="1.2.0",
@@ -14,20 +14,19 @@ setup(name='tap-harvest-forecast',
           'requests==2.33.0',
           'backoff==2.2.1'
       ],
+      extras_require={
+        "dev": [
+            "pytest",
+            "coverage",
+        ]
+    },
       entry_points='''
           [console_scripts]
           tap-harvest-forecast=tap_harvest_forecast:main
       ''',
-      packages=['tap_harvest_forecast'],
+      packages=find_packages(),
       package_data = {
-          'tap_harvest_forecast/schemas': [
-            "assignments.json",
-            "clients.json",
-            "milestones.json",
-            "people.json",
-            "projects.json",
-            "roles.json"
-          ],
+          'tap_harvest_forecast': ['schemas/*.json'],
       },
       include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(name='tap-harvest-forecast',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_harvest_forecast'],
       install_requires=[
-          'singer-python==5.14.3',
-          'requests==2.32.5',
-          'backoff==1.10.0'
+          'singer-python==6.8.0',
+          'requests==2.33.0',
+          'backoff==2.2.1'
       ],
       entry_points='''
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-harvest-forecast',
-      version="1.1.5",
+      version="1.2.0",
       description='Singer.io tap for extracting data from the Harvest Forecast api',
       author='Robert Benjamin',
       url='https://github.com/singer-io/tap-harvest-forecast',

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -101,9 +101,13 @@ def load_schema(entity):
 
 
 def get_start(key):
+    bookmark = STATE.get('bookmarks', {}).get(key, {}).get(REPLICATION_KEY)
+    if bookmark:
+        return bookmark
+    # Fall back to flat format for backwards compatibility
     if key not in STATE:
-        STATE[key] = CONFIG['start_date']
-
+        STATE.setdefault('bookmarks', {}).setdefault(key, {})[REPLICATION_KEY] = CONFIG['start_date']
+        return CONFIG['start_date']
     return STATE[key]
 
 def get_end(key):
@@ -190,19 +194,44 @@ def sync_endpoint(catalog_entry, schema, mdata, date_fields = None):
                         time_extracted=time_extracted)
                     singer.write_message(new_record)
 
-                    utils.update_state(STATE, catalog_entry.tap_stream_id, updated_at)
+                    STATE.setdefault('bookmarks', {}).setdefault(catalog_entry.tap_stream_id, {})
+                    current = STATE['bookmarks'][catalog_entry.tap_stream_id].get(REPLICATION_KEY, '')
+                    new_val = utils.strftime(updated_at)
+                    if not current or new_val >= current:
+                        STATE['bookmarks'][catalog_entry.tap_stream_id][REPLICATION_KEY] = new_val
 
 
     singer.write_state(STATE)
 
 def do_sync(catalog):
     LOGGER.info("Starting sync")
+
+    selected_streams = []
     for stream in catalog.streams:
         mdata = metadata.to_map(stream.metadata)
-        is_selected = metadata.get(mdata, (), 'selected')
-        if is_selected:
-            sync_endpoint(stream, stream.schema.to_dict(), mdata)
+        if metadata.get(mdata, (), 'selected'):
+            selected_streams.append(stream)
 
+    # Sort streams alphabetically by tap_stream_id
+    selected_streams.sort(key=lambda s: s.tap_stream_id)
+
+    currently_syncing = STATE.get('currently_syncing')
+    if currently_syncing:
+        # Find the index of the currently_syncing stream and reorder:
+        # interrupted stream first, then remaining in order
+        stream_ids = [s.tap_stream_id for s in selected_streams]
+        if currently_syncing in stream_ids:
+            idx = stream_ids.index(currently_syncing)
+            selected_streams = selected_streams[idx:] + selected_streams[:idx]
+
+    for stream in selected_streams:
+        STATE['currently_syncing'] = stream.tap_stream_id
+        singer.write_state(STATE)
+        sync_endpoint(stream, stream.schema.to_dict(),
+                      metadata.to_map(stream.metadata))
+
+    STATE.pop('currently_syncing', None)
+    singer.write_state(STATE)
     LOGGER.info("Sync complete")
 
 def do_discover():
@@ -212,11 +241,17 @@ def do_discover():
 
         mdata = metadata.new()
 
+        has_replication_key = REPLICATION_KEY in schema['properties']
+
         mdata = metadata.write(mdata, (), 'table-key-properties', [PRIMARY_KEY])
-        mdata = metadata.write(mdata, (), 'valid-replication-keys', [REPLICATION_KEY])
+        if has_replication_key:
+            mdata = metadata.write(mdata, (), 'valid-replication-keys', [REPLICATION_KEY])
+            mdata = metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
+        else:
+            mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
 
         for field_name in schema['properties'].keys():
-            if field_name == PRIMARY_KEY or field_name == REPLICATION_KEY:
+            if field_name == PRIMARY_KEY or (has_replication_key and field_name == REPLICATION_KEY):
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
             else:
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')

--- a/tap_harvest_forecast/schemas/people.json
+++ b/tap_harvest_forecast/schemas/people.json
@@ -56,7 +56,10 @@
       ]
     },
     "roles": {
-      "type": "array",
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": "string"
       }
@@ -87,7 +90,10 @@
       ]
     },
     "working_days": {
-      "type": "object",
+      "type": [
+        "null",
+        "object"
+      ],
       "properties": {
         "monday": {
           "type": [

--- a/tap_harvest_forecast/schemas/placeholders.json
+++ b/tap_harvest_forecast/schemas/placeholders.json
@@ -33,7 +33,10 @@
         ]
       },
       "roles": {
-        "type": "array",
+        "type": [
+          "null",
+          "array"
+        ],
         "items": {
           "type": "string"
         }

--- a/tap_harvest_forecast/schemas/projects.json
+++ b/tap_harvest_forecast/schemas/projects.json
@@ -77,7 +77,10 @@
       ]
     },
     "tags": {
-      "type": "array",
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
         "type": "string"
       }

--- a/tap_harvest_forecast/schemas/roles.json
+++ b/tap_harvest_forecast/schemas/roles.json
@@ -20,7 +20,10 @@
         ]
       },
       "person_ids": {
-        "type": "array",
+        "type": [
+          "null",
+          "array"
+        ],
         "items": {
           "type": "integer"
         }
@@ -39,7 +42,10 @@
         ]
       },
       "placeholder_ids": {
-        "type": "array",
+        "type": [
+          "null",
+          "array"
+        ],
         "items": {
           "type": "integer"
         }

--- a/tap_harvest_forecast/schemas/roles.json
+++ b/tap_harvest_forecast/schemas/roles.json
@@ -28,19 +28,6 @@
           "type": "integer"
         }
       },
-      "updated_at": {
-        "type": [
-          "null",
-          "string"
-        ],
-        "format": "date-time"
-      },
-      "updated_by_id": {
-        "type": [
-          "null",
-          "integer"
-        ]
-      },
       "placeholder_ids": {
         "type": [
           "null",

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,186 @@
+"""
+Base test class for tap-harvest-forecast mock integration tests.
+"""
+import json
+import os
+from singer.catalog import CatalogEntry
+from singer.schema import Schema
+
+
+class HarvestForecastBaseTest:
+    """Base test class providing common mock data and utilities."""
+
+    # Mock configuration
+    MOCK_CONFIG = {
+        "start_date": "2024-01-01T00:00:00Z",
+        "account_id": "test_account_123",
+        "client_id": "test_client_id",
+        "client_secret": "test_client_secret",
+        "refresh_token": "test_refresh_token",
+    }
+
+    EXPECTED_STREAMS = {
+        "assignments",
+        "clients",
+        "milestones",
+        "people",
+        "projects",
+        "roles",
+    }
+
+    EXPECTED_METADATA = {
+        "assignments": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+        "clients": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+        "milestones": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+        "people": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+        "projects": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+        "roles": {
+            "primary_keys": {"id"},
+            "replication_method": "INCREMENTAL",
+            "replication_keys": {"updated_at"},
+        },
+    }
+
+    @classmethod
+    def _generate_stream_record(cls, stream_name, record_id=1, updated_at=None):
+        """Generate a mock record for the given stream."""
+        if updated_at is None:
+            updated_at = "2024-03-15T12:00:00Z"
+
+        base_record = {
+            "id": record_id,
+            "updated_at": updated_at,
+        }
+
+        # Add stream-specific fields
+        stream_fields = {
+            "assignments": {
+                "start_date": "2024-03-01",
+                "end_date": "2024-03-31",
+                "allocation": 40,
+                "notes": "Test assignment",
+                "updated_by_id": 100,
+                "project_id": 1,
+                "person_id": 50,
+                "placeholder_id": None,
+                "repeated_assignment_set_id": None,
+                "active_on_days_off": False,
+            },
+            "clients": {
+                "name": f"Client {record_id}",
+                "harvest_id": record_id * 100,
+                "archived": False,
+                "updated_by_id": 100,
+            },
+            "milestones": {
+                "name": f"Milestone {record_id}",
+                "date": "2024-04-01T00:00:00Z",
+                "updated_by_id": 100,
+                "project_id": 1,
+            },
+            "people": {
+                "first_name": "Test",
+                "last_name": f"Person {record_id}",
+                "email": f"test{record_id}@example.com",
+                "login": f"test{record_id}",
+                "admin": False,
+                "archived": False,
+                "subscribed": True,
+                "avatar_url": None,
+                "roles": ["Developer"],
+                "updated_by_id": "100",
+                "harvest_user_id": record_id * 100,
+                "weekly_capacity": 40,
+                "working_days": {
+                    "monday": True,
+                    "tuesday": True,
+                    "wednesday": True,
+                    "thursday": True,
+                    "friday": True,
+                    "saturday": False,
+                    "sunday": False,
+                },
+                "color_blind": None,
+                "personal_feed_token_id": None,
+            },
+            "projects": {
+                "name": f"Project {record_id}",
+                "color": "blue",
+                "code": f"PROJ{record_id}",
+                "notes": "Test project notes",
+                "start_date": "2024-01-01T00:00:00Z",
+                "end_date": "2024-12-31T00:00:00Z",
+                "harvest_id": record_id * 100,
+                "archived": False,
+                "updated_by_id": 100,
+                "client_id": 1,
+                "tags": ["development", "internal"],
+            },
+            "roles": {
+                "name": f"Role {record_id}",
+                "harvest_role_id": record_id * 100,
+                "person_ids": [50, 51],
+                "updated_by_id": 100,
+                "placeholder_ids": [10, 11],
+            },
+        }
+
+        base_record.update(stream_fields.get(stream_name, {}))
+        return base_record
+
+    @classmethod
+    def load_schema(cls, stream_name):
+        """Load the JSON schema for a given stream."""
+        schema_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "tap_harvest_forecast",
+            "schemas",
+            f"{stream_name}.json"
+        )
+        with open(schema_path) as f:
+            return json.load(f)
+
+    @classmethod
+    def create_catalog_entry(cls, stream_name, selected=True):
+        """
+        Create a CatalogEntry for testing with proper schema wrapper.
+
+        Args:
+            stream_name: Name of the stream
+            selected: Whether the stream should be marked as selected
+
+        Returns:
+            A CatalogEntry object ready for use in tests
+        """
+
+        schema_dict = cls.load_schema(stream_name)
+        schema_obj = Schema.from_dict(schema_dict)
+
+        catalog_entry = CatalogEntry(
+            tap_stream_id=stream_name,
+            stream=stream_name,
+            schema=schema_obj,
+            metadata=[{"breadcrumb": [], "metadata": {"selected": selected}}]
+        )
+        return catalog_entry

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,187 +1,101 @@
 """
-Base test class for tap-harvest-forecast mock integration tests.
+Base test class for tap-harvest-forecast integration tests.
 """
-import json
 import os
-from singer.catalog import CatalogEntry
-from singer.schema import Schema
+
+from tap_tester.base_suite_tests.base_case import BaseCase
 
 
-class HarvestForecastBaseTest:
-    """Base test class providing common mock data and utilities."""
+class HarvestForecastBaseTest(BaseCase):
+    """Setup expectations for test sub classes.
 
-    # Mock configuration
-    MOCK_CONFIG = {
-        "start_date": "2024-01-01T00:00:00Z",
-        "end_date": "2024-12-31",
-        "account_id": "test_account_123",
-        "client_id": "test_client_id",
-        "client_secret": "test_client_secret",
-        "refresh_token": "test_refresh_token",
-    }
+    Metadata describing streams. A bunch of shared methods that are used
+    in tap-tester tests. Shared tap-specific methods (as needed).
+    """
 
-    EXPECTED_STREAMS = {
-        "assignments",
-        "clients",
-        "milestones",
-        "people",
-        "projects",
-        "roles",
-    }
+    start_date = "2026-03-01T00:00:00Z"
 
-    EXPECTED_METADATA = {
-        "assignments": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-        "clients": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-        "milestones": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-        "people": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-        "projects": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-        "roles": {
-            "primary_keys": {"id"},
-            "replication_method": "INCREMENTAL",
-            "replication_keys": {"updated_at"},
-        },
-    }
+    @staticmethod
+    def tap_name():
+        """The name of the tap."""
+        return "tap-harvest-forecast"
+
+    @staticmethod
+    def get_type():
+        """The expected connection type in Stitch."""
+        return "platform.harvest-forecast"
 
     @classmethod
-    def _generate_stream_record(cls, stream_name, record_id=1, updated_at=None):
-        """Generate a mock record for the given stream."""
-        if updated_at is None:
-            updated_at = "2024-03-15T12:00:00Z"
-
-        base_record = {
-            "id": record_id,
-            "updated_at": updated_at,
-        }
-
-        # Add stream-specific fields
-        stream_fields = {
+    def expected_metadata(cls):
+        """The expected streams and metadata about the streams."""
+        return {
             "assignments": {
-                "start_date": "2024-03-01",
-                "end_date": "2024-03-31",
-                "allocation": 40,
-                "notes": "Test assignment",
-                "updated_by_id": 100,
-                "project_id": 1,
-                "person_id": 50,
-                "placeholder_id": None,
-                "repeated_assignment_set_id": None,
-                "active_on_days_off": False,
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"updated_at"},
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
             "clients": {
-                "name": f"Client {record_id}",
-                "harvest_id": record_id * 100,
-                "archived": False,
-                "updated_by_id": 100,
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"updated_at"},
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
             "milestones": {
-                "name": f"Milestone {record_id}",
-                "date": "2024-04-01T00:00:00Z",
-                "updated_by_id": 100,
-                "project_id": 1,
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"updated_at"},
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
             "people": {
-                "first_name": "Test",
-                "last_name": f"Person {record_id}",
-                "email": f"test{record_id}@example.com",
-                "login": f"test{record_id}",
-                "admin": False,
-                "archived": False,
-                "subscribed": True,
-                "avatar_url": None,
-                "roles": ["Developer"],
-                "updated_by_id": "100",
-                "harvest_user_id": record_id * 100,
-                "weekly_capacity": 40,
-                "working_days": {
-                    "monday": True,
-                    "tuesday": True,
-                    "wednesday": True,
-                    "thursday": True,
-                    "friday": True,
-                    "saturday": False,
-                    "sunday": False,
-                },
-                "color_blind": None,
-                "personal_feed_token_id": None,
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"updated_at"},
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
             "projects": {
-                "name": f"Project {record_id}",
-                "color": "blue",
-                "code": f"PROJ{record_id}",
-                "notes": "Test project notes",
-                "start_date": "2024-01-01T00:00:00Z",
-                "end_date": "2024-12-31T00:00:00Z",
-                "harvest_id": record_id * 100,
-                "archived": False,
-                "updated_by_id": 100,
-                "client_id": 1,
-                "tags": ["development", "internal"],
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"updated_at"},
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
             "roles": {
-                "name": f"Role {record_id}",
-                "harvest_role_id": record_id * 100,
-                "person_ids": [50, 51],
-                "updated_by_id": 100,
-                "placeholder_ids": [10, 11],
+                cls.PRIMARY_KEYS: {"id"},
+                cls.REPLICATION_METHOD: cls.FULL_TABLE,
+                cls.REPLICATION_KEYS: set(),
+                cls.OBEYS_START_DATE: True,
+                cls.API_LIMIT: 100,
             },
         }
 
-        base_record.update(stream_fields.get(stream_name, {}))
-        return base_record
+    @staticmethod
+    def get_credentials():
+        """Authentication information for the test account."""
+        credentials_dict = {}
+        creds = {
+            'client_id': 'TAP_HARVEST_FORECAST_CLIENT_ID',
+            'client_secret': 'TAP_HARVEST_FORECAST_CLIENT_SECRET',
+            'refresh_token': 'TAP_HARVEST_FORECAST_REFRESH_TOKEN',
+        }
 
-    @classmethod
-    def load_schema(cls, stream_name):
-        """Load the JSON schema for a given stream."""
-        schema_path = os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "tap_harvest_forecast",
-            "schemas",
-            f"{stream_name}.json"
-        )
-        with open(schema_path) as f:
-            return json.load(f)
+        for cred in creds:
+            credentials_dict[cred] = os.getenv(creds[cred])
 
-    @classmethod
-    def create_catalog_entry(cls, stream_name, selected=True):
-        """
-        Create a CatalogEntry for testing with proper schema wrapper.
+        return credentials_dict
 
-        Args:
-            stream_name: Name of the stream
-            selected: Whether the stream should be marked as selected
+    def get_properties(self, original: bool = True):
+        """Configuration of properties required for the tap."""
+        return_value = {
+            "start_date": self.start_date,
+            "account_id": os.getenv('TAP_HARVEST_FORECAST_ACCOUNT_ID'),
+        }
+        if original:
+            return return_value
 
-        Returns:
-            A CatalogEntry object ready for use in tests
-        """
-
-        schema_dict = cls.load_schema(stream_name)
-        schema_obj = Schema.from_dict(schema_dict)
-
-        catalog_entry = CatalogEntry(
-            tap_stream_id=stream_name,
-            stream=stream_name,
-            schema=schema_obj,
-            metadata=[{"breadcrumb": [], "metadata": {"selected": selected}}]
-        )
-        return catalog_entry
+        return_value["start_date"] = self.start_date
+        return return_value

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,6 +13,7 @@ class HarvestForecastBaseTest:
     # Mock configuration
     MOCK_CONFIG = {
         "start_date": "2024-01-01T00:00:00Z",
+        "end_date": "2024-12-31",
         "account_id": "test_account_123",
         "client_id": "test_client_id",
         "client_secret": "test_client_secret",

--- a/tests/mock_integration/base.py
+++ b/tests/mock_integration/base.py
@@ -1,0 +1,212 @@
+"""
+Base class for mock integration tests for tap-harvest-forecast.
+
+Runs the real tap code against mocked HTTP responses — no external
+tap-tester dependency and no actual API credentials required.
+Mock data is generated dynamically from the JSON schema files.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+from singer import metadata, Catalog, CatalogEntry
+from singer.schema import Schema
+
+import tap_harvest_forecast as thf
+
+from .mock_data_generator import MockDataGenerator
+
+
+SCHEMAS_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(thf.__file__)),
+    'schemas',
+)
+
+STREAM_CONFIG = {
+    'assignments': {
+        'replication_method': 'INCREMENTAL',
+        'replication_key': 'updated_at',
+        'record_count': 3,
+        'date_fields': ['start_date', 'end_date'],
+    },
+    'clients': {
+        'replication_method': 'INCREMENTAL',
+        'replication_key': 'updated_at',
+        'record_count': 3,
+        'date_fields': [],
+    },
+    'milestones': {
+        'replication_method': 'INCREMENTAL',
+        'replication_key': 'updated_at',
+        'record_count': 3,
+        'date_fields': [],
+    },
+    'people': {
+        'replication_method': 'INCREMENTAL',
+        'replication_key': 'updated_at',
+        'record_count': 3,
+        'date_fields': [],
+    },
+    'projects': {
+        'replication_method': 'INCREMENTAL',
+        'replication_key': 'updated_at',
+        'record_count': 3,
+        'date_fields': ['start_date', 'end_date'],
+    },
+    'roles': {
+        'replication_method': 'FULL_TABLE',
+        'replication_key': None,
+        'record_count': 2,
+        'date_fields': [],
+    },
+}
+
+ALL_STREAM_IDS = set(STREAM_CONFIG.keys())
+
+INCREMENTAL_STREAMS = {
+    name for name, cfg in STREAM_CONFIG.items()
+    if cfg['replication_method'] == 'INCREMENTAL'
+}
+
+FULL_TABLE_STREAMS = {
+    name for name, cfg in STREAM_CONFIG.items()
+    if cfg['replication_method'] == 'FULL_TABLE'
+}
+
+DEFAULT_CONFIG = {
+    'start_date': '2026-03-01T00:00:00Z',
+    'end_date': '2026-06-01',
+    'account_id': 'test_account_123',
+    'client_id': 'test_client_id',
+    'client_secret': 'test_client_secret',
+    'refresh_token': 'test_refresh_token',
+}
+
+
+class HarvestForecastMockBaseTest:
+    """Shared helpers for mock integration tests."""
+
+    default_config = DEFAULT_CONFIG.copy()
+
+    _generator = MockDataGenerator(SCHEMAS_DIR)
+
+    @classmethod
+    def _get_mock_records(cls, stream_name, updated_at_base='2026-04-15T10:00:00Z'):
+        """Return dynamically generated mock records with deterministic updated_at values."""
+        cfg = STREAM_CONFIG[stream_name]
+        count = cfg['record_count']
+        rep_key = cfg['replication_key']
+
+        records = []
+        for i in range(count):
+            rec = cls._generator.generate_record(stream_name, seed=i)
+            if rep_key:
+                # Set deterministic, increasing updated_at values
+                rec[rep_key] = f"2026-04-{15 + i:02d}T10:00:00Z"
+            records.append(rec)
+        return records
+
+    @classmethod
+    def _make_mock_auth(cls):
+        """Create a mock AUTH object."""
+        auth = MagicMock()
+        auth.get_access_token.return_value = 'mock_access_token'
+        auth.get_account_id.return_value = 'mock_account_123'
+        return auth
+
+    @classmethod
+    def _make_mock_request(cls):
+        """Return a side_effect function for patching tap_harvest_forecast.request.
+
+        Extracts the stream name from the URL path and returns
+        ``{stream_name: [records]}``.
+        """
+        def mock_request(url, params=None):
+            stream_name = url.rstrip('/').split('/')[-1]
+            records = cls._get_mock_records(stream_name) if stream_name in STREAM_CONFIG else []
+            return {stream_name: records}
+        return mock_request
+
+    @classmethod
+    def _build_catalog(cls):
+        """Build a Catalog object from the tap's discover logic without stdout."""
+        streams = []
+        for endpoint in thf.ENDPOINTS:
+            schema_dict = thf.load_schema(endpoint)
+            schema_obj = Schema.from_dict(schema_dict)
+            mdata = metadata.new()
+            has_rep_key = thf.REPLICATION_KEY in schema_dict.get('properties', {})
+
+            mdata = metadata.write(mdata, (), 'table-key-properties', [thf.PRIMARY_KEY])
+            if has_rep_key:
+                mdata = metadata.write(mdata, (), 'valid-replication-keys', [thf.REPLICATION_KEY])
+                mdata = metadata.write(mdata, (), 'forced-replication-method', 'INCREMENTAL')
+            else:
+                mdata = metadata.write(mdata, (), 'forced-replication-method', 'FULL_TABLE')
+
+            for field_name in schema_dict['properties']:
+                if field_name == thf.PRIMARY_KEY or (has_rep_key and field_name == thf.REPLICATION_KEY):
+                    mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+                else:
+                    mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'available')
+
+            entry = CatalogEntry(
+                stream=endpoint,
+                tap_stream_id=endpoint,
+                key_properties=[thf.PRIMARY_KEY],
+                schema=schema_obj,
+                metadata=metadata.to_list(mdata),
+            )
+            streams.append(entry)
+        return Catalog(streams)
+
+    @classmethod
+    def _make_selected_catalog(cls, stream_names=None):
+        """Return a catalog with *stream_names* selected (None = select all)."""
+        catalog = cls._build_catalog()
+        for entry in catalog.streams:
+            is_selected = stream_names is None or entry.tap_stream_id in stream_names
+            mdata = metadata.to_map(entry.metadata)
+            mdata = metadata.write(mdata, (), 'selected', is_selected)
+            entry.metadata = metadata.to_list(mdata)
+        return catalog
+
+    def run_sync(self, catalog, state=None, config=None):
+        """Run do_sync and return (written_records, final_state).
+
+        Uses patch.dict on the module-level STATE and CONFIG dicts so that
+        in-place mutations made by sync_endpoint are visible during the call
+        and captured before the patch is torn down.
+        """
+        test_state = state if state is not None else {}
+        test_config = config if config is not None else self.default_config.copy()
+        written_records = []
+
+        def capture_message(msg):
+            if hasattr(msg, 'record'):
+                written_records.append((msg.stream, msg.record))
+
+        with patch.dict(thf.STATE, test_state, clear=True), \
+             patch.dict(thf.CONFIG, test_config, clear=True), \
+             patch.object(thf, 'AUTH', self._make_mock_auth()), \
+             patch.object(thf, 'request', side_effect=self._make_mock_request()), \
+             patch('singer.write_state'), \
+             patch('singer.write_schema'), \
+             patch('singer.write_message', side_effect=capture_message):
+            thf.do_sync(catalog)
+            # Capture state snapshot _inside_ the patch context, before teardown.
+            final_state = {k: v for k, v in thf.STATE.items()}
+
+        return written_records, final_state
+
+    @classmethod
+    def get_max_bookmark(cls, stream_name):
+        """Return the max replication_key value from mock records."""
+        rep_key = STREAM_CONFIG[stream_name]['replication_key']
+        if not rep_key:
+            return None
+        return max(r[rep_key] for r in cls._get_mock_records(stream_name))
+
+    @classmethod
+    def get_initial_bookmark(cls, stream_name):
+        """Return a bookmark date before all mock records for *stream_name*."""
+        return '2026-04-01T00:00:00Z'

--- a/tests/mock_integration/mock_data_generator.py
+++ b/tests/mock_integration/mock_data_generator.py
@@ -1,0 +1,90 @@
+"""Generic mock data generator for Singer tap integration tests.
+
+Reads JSON schema files and generates mock API response data with
+deterministic, type-conformant values.
+"""
+import json
+import os
+from datetime import datetime, timedelta
+
+
+class MockDataGenerator:
+    """Generates mock records from JSON schema files.
+
+    Usage::
+
+        gen = MockDataGenerator('/path/to/tap_harvest_forecast/schemas')
+        record = gen.generate_record('clients', seed=0)
+        records = gen.generate_records('clients', count=3)
+    """
+
+    BASE_DATE = datetime(2026, 4, 15, 10, 0, 0)
+
+    def __init__(self, schemas_dir):
+        self.schemas_dir = schemas_dir
+        self._schema_cache = {}
+
+    def load_schema(self, stream_name):
+        """Load and cache a JSON schema file for *stream_name*."""
+        if stream_name not in self._schema_cache:
+            path = os.path.join(self.schemas_dir, f'{stream_name}.json')
+            with open(path) as f:
+                self._schema_cache[stream_name] = json.load(f)
+        return self._schema_cache[stream_name]
+
+    @staticmethod
+    def resolve_type(type_spec):
+        """Return the first non-null type from a JSON-Schema *type* field."""
+        if isinstance(type_spec, list):
+            for t in type_spec:
+                if t != 'null':
+                    return t
+            return 'string'
+        return type_spec
+
+    def generate_value(self, field_name, field_schema, seed=0):
+        """Return a deterministic value that conforms to *field_schema*."""
+        type_str = self.resolve_type(field_schema.get('type', 'string'))
+        fmt = field_schema.get('format')
+
+        if fmt == 'date-time':
+            dt = self.BASE_DATE + timedelta(days=seed)
+            return dt.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        if type_str == 'string':
+            return f"mock-{field_name.lower()}-{seed}"
+        if type_str == 'number':
+            return round(42.5 + seed * 1.1, 2)
+        if type_str == 'integer':
+            return 100 + seed
+        if type_str == 'boolean':
+            return seed % 2 == 0
+        if type_str == 'array':
+            items_schema = field_schema.get('items', {})
+            if items_schema.get('properties'):
+                return [self.generate_value(field_name + '_item', items_schema, seed)]
+            return []
+        if type_str == 'object':
+            props = field_schema.get('properties', {})
+            if props:
+                return {k: self.generate_value(k, v, seed) for k, v in props.items()}
+            return {}
+        return f"mock-{seed}"
+
+    def generate_record(self, stream_name, seed=0, overrides=None):
+        """Return a single mock record for *stream_name* based on its schema."""
+        schema = self.load_schema(stream_name)
+        properties = schema.get('properties', {})
+        record = {}
+        for i, (field_name, field_schema) in enumerate(properties.items()):
+            record[field_name] = self.generate_value(field_name, field_schema, seed + i)
+        # Ensure deterministic integer id
+        record['id'] = 1000 + seed
+        if overrides:
+            record.update(overrides)
+        return record
+
+    def generate_records(self, stream_name, count=2, overrides=None):
+        """Return *count* mock records for *stream_name*."""
+        return [self.generate_record(stream_name, seed=i, overrides=overrides)
+                for i in range(count)]

--- a/tests/mock_integration/test_all_fields.py
+++ b/tests/mock_integration/test_all_fields.py
@@ -1,0 +1,80 @@
+"""Mock integration test: all fields — running the tap with all streams and
+fields selected replicates all fields defined in the schema."""
+import unittest
+
+from .base import (
+    HarvestForecastMockBaseTest,
+    ALL_STREAM_IDS,
+    STREAM_CONFIG,
+)
+
+# Fields present in schema but known to be absent from real API responses.
+# Documented here so tests are not broken by these known gaps.
+KNOWN_MISSING_FIELDS = {
+    'roles': {'updated_at', 'updated_by_id'},
+}
+
+
+class AllFieldsMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def setUp(self):
+        self.catalog = self._make_selected_catalog()
+
+    def test_sync_writes_records_for_all_streams(self):
+        records, _ = self.run_sync(self.catalog)
+        written_streams = {s for s, _ in records}
+        for stream in ALL_STREAM_IDS:
+            with self.subTest(stream=stream):
+                self.assertIn(stream, written_streams)
+
+    def test_records_have_primary_key(self):
+        records, _ = self.run_sync(self.catalog)
+        for stream in ALL_STREAM_IDS:
+            with self.subTest(stream=stream):
+                recs = [r for s, r in records if s == stream]
+                self.assertTrue(len(recs) > 0, f"No records for {stream}")
+                for rec in recs:
+                    self.assertIn('id', rec)
+                    self.assertIsNotNone(rec['id'])
+
+    def test_correct_record_counts(self):
+        records, _ = self.run_sync(self.catalog)
+        # Each stream should write exactly record_count unique records (dedup by id)
+        for stream, cfg in STREAM_CONFIG.items():
+            with self.subTest(stream=stream):
+                written_ids = [r['id'] for s, r in records if s == stream]
+                self.assertEqual(
+                    len(written_ids), cfg['record_count'],
+                    f"{stream}: expected {cfg['record_count']} records, got {len(written_ids)}",
+                )
+
+    def test_schema_fields_present_in_records(self):
+        """Verify that every field from the schema appears in synced records
+        (excluding known missing fields)."""
+        records, _ = self.run_sync(self.catalog)
+        for stream in ALL_STREAM_IDS:
+            with self.subTest(stream=stream):
+                schema = self._generator.load_schema(stream)
+                schema_fields = set(schema.get('properties', {}).keys())
+                missing_ok = KNOWN_MISSING_FIELDS.get(stream, set())
+
+                recs = [r for s, r in records if s == stream]
+                self.assertGreater(len(recs), 0, f"No records for {stream}")
+
+                for rec in recs:
+                    rec_fields = set(rec.keys())
+                    unexpected_missing = (schema_fields - missing_ok) - rec_fields
+                    self.assertEqual(
+                        unexpected_missing, set(),
+                        f"{stream}: unexpected missing fields: {unexpected_missing}",
+                    )
+
+    def test_sync_only_selected_stream(self):
+        """When only one stream is selected, only it writes records."""
+        catalog = self._make_selected_catalog(stream_names=['clients'])
+        records, _ = self.run_sync(catalog)
+        written_streams = {s for s, _ in records}
+        self.assertIn('clients', written_streams)
+        for other in ALL_STREAM_IDS - {'clients'}:
+            self.assertNotIn(other, written_streams,
+                f"Stream '{other}' should not have records when not selected")

--- a/tests/mock_integration/test_automatic_fields.py
+++ b/tests/mock_integration/test_automatic_fields.py
@@ -1,0 +1,108 @@
+"""Mock integration test: automatic fields — primary key and replication key
+are marked inclusion=automatic in discover metadata."""
+import unittest
+
+from singer import metadata
+
+from .base import (
+    HarvestForecastMockBaseTest,
+    STREAM_CONFIG,
+    INCREMENTAL_STREAMS,
+)
+
+
+class AutomaticFieldsMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def setUp(self):
+        self.catalog = self._build_catalog()
+
+    def test_primary_key_is_automatic(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                inclusion = mdata.get(('properties', 'id'), {}).get('inclusion')
+                self.assertEqual(inclusion, 'automatic')
+
+    def test_replication_key_is_automatic_for_incremental(self):
+        for entry in self.catalog.streams:
+            if entry.tap_stream_id not in INCREMENTAL_STREAMS:
+                continue
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                inclusion = mdata.get(('properties', 'updated_at'), {}).get('inclusion')
+                self.assertEqual(inclusion, 'automatic')
+
+    def test_non_key_fields_are_available(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                cfg = STREAM_CONFIG[entry.tap_stream_id]
+                auto_fields = {'id'}
+                if cfg['replication_key']:
+                    auto_fields.add(cfg['replication_key'])
+
+                schema_props = entry.schema.to_dict().get('properties', {})
+                for field in schema_props:
+                    breadcrumb = ('properties', field)
+                    inclusion = mdata.get(breadcrumb, {}).get('inclusion')
+                    if field in auto_fields:
+                        self.assertEqual(
+                            inclusion, 'automatic',
+                            f"'{entry.tap_stream_id}.{field}' expected 'automatic', got '{inclusion}'",
+                        )
+                    else:
+                        self.assertEqual(
+                            inclusion, 'available',
+                            f"'{entry.tap_stream_id}.{field}' expected 'available', got '{inclusion}'",
+                        )
+
+    def test_primary_key_in_schema(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                props = entry.schema.to_dict().get('properties', {})
+                self.assertIn('id', props)
+
+    def test_automatic_fields_always_present_in_records(self):
+        """Verify automatic fields appear in synced records even with minimal selection."""
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                records, _ = self.run_sync(catalog)
+                stream_records = [r for s, r in records if s == stream_name]
+                self.assertGreater(len(stream_records), 0,
+                    f"Expected records for {stream_name}")
+                for rec in stream_records:
+                    self.assertIn('id', rec)
+                    self.assertIn('updated_at', rec)
+
+    def test_primary_key_always_populated(self):
+        """Verify primary key (id) is present and non-null in every synced record.
+        Matches previously approved mock test."""
+        for stream_name in STREAM_CONFIG:
+            with self.subTest(stream=stream_name):
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                records, _ = self.run_sync(catalog)
+                stream_records = [r for s, r in records if s == stream_name]
+                self.assertGreater(len(stream_records), 0,
+                    f"Expected records for {stream_name}")
+                for rec in stream_records:
+                    self.assertIn('id', rec,
+                        f"{stream_name}: 'id' missing from record")
+                    self.assertIsNotNone(rec['id'],
+                        f"{stream_name}: 'id' should not be null")
+
+    def test_replication_key_always_populated(self):
+        """Verify replication key (updated_at) is present and non-null in every
+        synced record for INCREMENTAL streams. Matches previously approved mock test."""
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                records, _ = self.run_sync(catalog)
+                stream_records = [r for s, r in records if s == stream_name]
+                self.assertGreater(len(stream_records), 0,
+                    f"Expected records for {stream_name}")
+                for rec in stream_records:
+                    self.assertIn('updated_at', rec,
+                        f"{stream_name}: 'updated_at' missing from record")
+                    self.assertIsNotNone(rec['updated_at'],
+                        f"{stream_name}: 'updated_at' should not be null")

--- a/tests/mock_integration/test_bookmark.py
+++ b/tests/mock_integration/test_bookmark.py
@@ -1,0 +1,126 @@
+"""Mock integration test: bookmark / incremental sync — verify state is
+updated correctly and previous bookmarks are respected."""
+import unittest
+from singer import utils as singer_utils
+
+from .base import (
+    HarvestForecastMockBaseTest,
+    STREAM_CONFIG,
+    INCREMENTAL_STREAMS,
+    FULL_TABLE_STREAMS,
+)
+
+
+class BookmarkMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def test_state_has_bookmarks_after_sync(self):
+        """After syncing, STATE must contain bookmarks for INCREMENTAL streams."""
+        catalog = self._make_selected_catalog()
+        _, state = self.run_sync(catalog)
+        self.assertIn('bookmarks', state)
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                self.assertIn(stream, state['bookmarks'])
+                self.assertIn('updated_at', state['bookmarks'][stream])
+
+    def test_bookmark_advances_to_latest_record(self):
+        """Bookmark should be set to the max updated_at across synced records."""
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                initial_state = {
+                    'bookmarks': {stream: {'updated_at': self.get_initial_bookmark(stream)}}
+                }
+                _, state = self.run_sync(catalog, state=initial_state)
+
+                max_expected = self.get_max_bookmark(stream)
+                actual_bookmark = state['bookmarks'][stream]['updated_at']
+                # Bookmark must have advanced to (or past) the latest record
+                self.assertGreaterEqual(
+                    singer_utils.strptime_to_utc(actual_bookmark),
+                    singer_utils.strptime_to_utc(max_expected),
+                    f"{stream}: bookmark {actual_bookmark} did not advance to {max_expected}",
+                )
+
+    def test_bookmark_filters_earlier_records(self):
+        """Records with updated_at < existing bookmark should NOT be written."""
+        bookmark = '2026-04-16T10:00:00Z'
+        bookmark_dt = singer_utils.strptime_to_utc(bookmark)
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                initial_state = {'bookmarks': {stream: {'updated_at': bookmark}}}
+                records, _ = self.run_sync(catalog, state=initial_state)
+
+                stream_records = [r for s, r in records if s == stream]
+                for rec in stream_records:
+                    rec_dt = singer_utils.strptime_to_utc(rec['updated_at'])
+                    self.assertGreaterEqual(
+                        rec_dt, bookmark_dt,
+                        f"{stream}: record updated_at={rec['updated_at']} is before bookmark={bookmark}",
+                    )
+
+    def test_full_table_streams_have_no_bookmark(self):
+        """FULL_TABLE streams must not advance bookmark beyond config start_date.
+        The tap sets start_date as the initial bookmark but must not update it
+        from record data (roles has no updated_at field)."""
+        catalog = self._make_selected_catalog()
+        start_date = self.default_config['start_date']
+        _, state = self.run_sync(catalog)
+        for stream in FULL_TABLE_STREAMS:
+            with self.subTest(stream=stream):
+                stream_bm = state.get('bookmarks', {}).get(stream, {})
+                # If a bookmark was written it must equal the config start_date
+                if 'updated_at' in stream_bm:
+                    self.assertEqual(
+                        stream_bm['updated_at'], start_date,
+                        f"{stream}: FULL_TABLE bookmark advanced past start_date — "
+                        f"expected {start_date}, got {stream_bm['updated_at']}",
+                    )
+
+    def test_fresh_sync_uses_config_start_date_as_initial_bookmark(self):
+        """With no existing state, start_date from CONFIG is the effective bookmark."""
+        start_date = '2026-03-01T00:00:00Z'
+        config = self.default_config.copy()
+        config['start_date'] = start_date
+
+        catalog = self._make_selected_catalog(stream_names=['assignments'])
+        records, _ = self.run_sync(catalog, state={}, config=config)
+
+        stream_records = [r for s, r in records if s == 'assignments']
+        # All mock records are after the start_date, so all 3 should appear
+        self.assertEqual(len(stream_records), STREAM_CONFIG['assignments']['record_count'])
+
+    def test_bookmark_is_set_during_sync(self):
+        """Verify STATE contains a bookmark entry for each INCREMENTAL stream after sync.
+        Ported from previously approved mock test."""
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                _, state = self.run_sync(catalog, state={})
+                bookmarks = state.get('bookmarks', {})
+                self.assertIn(stream_name, bookmarks,
+                    f"{stream_name}: STATE['bookmarks'] missing stream entry after sync")
+                self.assertIn('updated_at', bookmarks[stream_name],
+                    f"{stream_name}: bookmark missing 'updated_at' key")
+                self.assertIsNotNone(bookmarks[stream_name]['updated_at'],
+                    f"{stream_name}: bookmark 'updated_at' should not be null")
+
+    def test_bookmark_advances_to_max_updated_at(self):
+        """Verify bookmark equals the maximum updated_at value across all synced records.
+        Ported from previously approved mock test."""
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                latest_date = '2026-04-17T10:00:00Z'
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                _, state = self.run_sync(catalog, state={})
+
+                final_bookmark = state['bookmarks'][stream_name]['updated_at']
+                self.assertIsNotNone(final_bookmark)
+
+                final_dt = singer_utils.strptime_to_utc(final_bookmark)
+                latest_dt = singer_utils.strptime_to_utc(latest_date)
+                self.assertGreaterEqual(
+                    final_dt, latest_dt,
+                    f"{stream_name}: bookmark {final_bookmark} did not advance to {latest_date}",
+                )

--- a/tests/mock_integration/test_discovery.py
+++ b/tests/mock_integration/test_discovery.py
@@ -1,0 +1,101 @@
+"""Mock integration test: discovery produces correct catalog and metadata."""
+import unittest
+
+from singer import metadata
+
+from .base import HarvestForecastMockBaseTest, ALL_STREAM_IDS, INCREMENTAL_STREAMS
+
+
+class DiscoveryMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def setUp(self):
+        self.catalog = self._build_catalog()
+
+    def test_discovery_returns_all_streams(self):
+        stream_ids = {entry.tap_stream_id for entry in self.catalog.streams}
+        self.assertEqual(stream_ids, ALL_STREAM_IDS)
+
+    def test_key_properties_are_id(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                keys = mdata.get((), {}).get('table-key-properties', [])
+                self.assertEqual(keys, ['id'])
+
+    def test_schema_properties_exist(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                schema = entry.schema.to_dict()
+                self.assertIn('properties', schema)
+                self.assertGreater(len(schema['properties']), 0)
+
+    def test_id_and_updated_at_in_schema_where_expected(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                props = entry.schema.to_dict().get('properties', {})
+                self.assertIn('id', props)
+                if entry.tap_stream_id in INCREMENTAL_STREAMS:
+                    self.assertIn('updated_at', props)
+
+    def test_replication_method_set(self):
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                rep_method = mdata.get((), {}).get('forced-replication-method')
+                self.assertIn(rep_method, ('INCREMENTAL', 'FULL_TABLE'))
+
+    def test_incremental_streams_have_valid_replication_keys(self):
+        for entry in self.catalog.streams:
+            if entry.tap_stream_id not in INCREMENTAL_STREAMS:
+                continue
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                valid_keys = mdata.get((), {}).get('valid-replication-keys')
+                self.assertIsNotNone(valid_keys)
+                self.assertIn('updated_at', valid_keys)
+
+    def test_full_table_streams_have_no_replication_keys(self):
+        from .base import FULL_TABLE_STREAMS
+        for entry in self.catalog.streams:
+            if entry.tap_stream_id not in FULL_TABLE_STREAMS:
+                continue
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                valid_keys = mdata.get((), {}).get('valid-replication-keys')
+                self.assertIsNone(valid_keys)
+
+    def test_discovery_metadata_includes_exact_keys(self):
+        """Verify table-key-properties == ['id'] and valid-replication-keys == ['updated_at']
+        for each stream — matches assertions from previously approved mock tests."""
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                mdata = metadata.to_map(entry.metadata)
+                table_keys = mdata.get((), {}).get('table-key-properties', [])
+                self.assertEqual(
+                    set(table_keys), {'id'},
+                    f"{entry.tap_stream_id}: expected table-key-properties={{'id'}}, got {set(table_keys)}",
+                )
+                if entry.tap_stream_id in INCREMENTAL_STREAMS:
+                    replication_keys = mdata.get((), {}).get('valid-replication-keys', [])
+                    self.assertEqual(
+                        set(replication_keys), {'updated_at'},
+                        f"{entry.tap_stream_id}: expected valid-replication-keys={{'updated_at'}}, "
+                        f"got {set(replication_keys)}",
+                    )
+
+    def test_discovery_schemas_are_valid(self):
+        """Verify each stream schema has type, properties dict, and 'id' field;
+        incremental streams also have 'updated_at'. Matches previous approved test."""
+        for entry in self.catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                schema = entry.schema.to_dict()
+                self.assertIn('type', schema,
+                    f"{entry.tap_stream_id}: schema missing 'type'")
+                self.assertIn('properties', schema,
+                    f"{entry.tap_stream_id}: schema missing 'properties'")
+                self.assertIsInstance(schema['properties'], dict)
+                self.assertIn('id', schema['properties'],
+                    f"{entry.tap_stream_id}: schema missing 'id' property")
+                if entry.tap_stream_id in INCREMENTAL_STREAMS:
+                    self.assertIn('updated_at', schema['properties'],
+                        f"{entry.tap_stream_id}: schema missing 'updated_at' property")

--- a/tests/mock_integration/test_interrupted_sync.py
+++ b/tests/mock_integration/test_interrupted_sync.py
@@ -1,0 +1,165 @@
+"""Mock integration test: interrupted sync — tap resumes from the stream
+stored in currently_syncing and clears it after a full successful sync."""
+import unittest
+from unittest.mock import patch
+from singer import utils as singer_utils
+
+import tap_harvest_forecast as thf
+
+from .base import (
+    HarvestForecastMockBaseTest,
+    ALL_STREAM_IDS,
+    INCREMENTAL_STREAMS,
+)
+
+
+class InterruptedSyncMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def test_currently_syncing_cleared_after_full_sync(self):
+        """STATE['currently_syncing'] must be removed after a complete sync."""
+        catalog = self._make_selected_catalog()
+        initial_state = {
+            'currently_syncing': 'milestones',
+            'bookmarks': {
+                'assignments': {'updated_at': '2026-04-16T10:00:00Z'},
+                'clients': {'updated_at': '2026-04-16T10:00:00Z'},
+            },
+        }
+        _, state = self.run_sync(catalog, state=initial_state)
+        self.assertNotIn('currently_syncing', state,
+            "currently_syncing should be cleared after a successful full sync")
+
+    def test_all_streams_processed_after_resume(self):
+        """Resuming a mid-sync interruption should still write records for all streams."""
+        catalog = self._make_selected_catalog()
+        # Interrupt mid-way at 'milestones' (alphabetical order: assignments, clients, milestones, ...)
+        initial_state = {
+            'currently_syncing': 'milestones',
+            'bookmarks': {
+                'assignments': {'updated_at': '2026-04-16T10:00:00Z'},
+                'clients': {'updated_at': '2026-04-16T10:00:00Z'},
+            },
+        }
+        records, _ = self.run_sync(catalog, state=initial_state)
+        written_streams = {s for s, _ in records}
+        for stream in ALL_STREAM_IDS:
+            with self.subTest(stream=stream):
+                self.assertIn(stream, written_streams,
+                    f"Stream '{stream}' should have been synced on resume")
+
+    def test_interrupted_stream_synced_before_previous_streams(self):
+        """The interrupted stream must be the FIRST stream processed on resume."""
+        synced_order = []
+        original = thf.sync_endpoint
+
+        def tracking_sync_endpoint(catalog_entry, schema, mdata, date_fields=None):
+            synced_order.append(catalog_entry.tap_stream_id)
+            return original(catalog_entry, schema, mdata, date_fields)
+
+        catalog = self._make_selected_catalog()
+        initial_state = {
+            'currently_syncing': 'people',
+            'bookmarks': {
+                'assignments': {'updated_at': '2026-04-17T00:00:00Z'},
+                'clients': {'updated_at': '2026-04-17T00:00:00Z'},
+                'milestones': {'updated_at': '2026-04-17T00:00:00Z'},
+            },
+        }
+
+        with patch.object(thf, 'sync_endpoint', side_effect=tracking_sync_endpoint):
+            self.run_sync(catalog, state=initial_state)
+
+        self.assertGreater(len(synced_order), 0, "sync_endpoint was never called")
+        self.assertEqual(synced_order[0], 'people',
+            f"Expected 'people' to be synced first on resume, got '{synced_order[0]}'")
+
+    def test_bookmarks_preserved_for_already_completed_streams(self):
+        """Bookmarks for streams already completed before the interruption are preserved."""
+        catalog = self._make_selected_catalog()
+        completed_bookmark = '2026-04-16T10:00:00Z'
+        initial_state = {
+            'currently_syncing': 'milestones',
+            'bookmarks': {
+                'assignments': {'updated_at': completed_bookmark},
+                'clients': {'updated_at': completed_bookmark},
+            },
+        }
+        _, state = self.run_sync(catalog, state=initial_state)
+
+        # Completed streams' bookmarks must not be erased
+        for stream in ('assignments', 'clients'):
+            self.assertIn(stream, state.get('bookmarks', {}),
+                f"Bookmark for '{stream}' was lost after interrupted sync resume")
+
+    def test_clean_sync_without_interruption_sets_no_currently_syncing(self):
+        """A fresh sync with no prior state must not leave currently_syncing behind."""
+        catalog = self._make_selected_catalog()
+        _, state = self.run_sync(catalog, state={})
+        self.assertNotIn('currently_syncing', state)
+
+    def test_sync_resumes_from_last_bookmark_on_interruption(self):
+        """Two-sync scenario: second sync only processes records >= bookmark from
+        first sync. Ported from previously approved mock test."""
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                # --- First sync: 3 records ---
+                batch_1 = [
+                    {'id': 1, 'updated_at': '2026-04-10T12:00:00Z'},
+                    {'id': 2, 'updated_at': '2026-04-12T12:00:00Z'},
+                    {'id': 3, 'updated_at': '2026-04-15T12:00:00Z'},
+                ]
+
+                def request_batch_1(url, params=None):
+                    sn = url.rstrip('/').split('/')[-1]
+                    return {sn: batch_1 if sn == stream_name else []}
+
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+
+                with patch.dict(thf.STATE, {}, clear=True), \
+                     patch.dict(thf.CONFIG, self.default_config.copy(), clear=True), \
+                     patch.object(thf, 'AUTH', self._make_mock_auth()), \
+                     patch.object(thf, 'request', side_effect=request_batch_1), \
+                     patch('singer.write_state'), \
+                     patch('singer.write_schema'), \
+                     patch('singer.write_message'):
+                    thf.do_sync(catalog)
+                    state_after_first = {k: v for k, v in thf.STATE.items()}
+
+                self.assertIn(stream_name, state_after_first.get('bookmarks', {}),
+                    f"{stream_name}: STATE missing bookmark after first sync")
+
+                bookmark_after_first = state_after_first['bookmarks'][stream_name]['updated_at']
+                bookmark_dt = singer_utils.strptime_to_utc(bookmark_after_first)
+
+                # --- Second sync: new records starting from overlap ---
+                batch_2 = [
+                    {'id': 3, 'updated_at': '2026-04-15T12:00:00Z'},  # overlap
+                    {'id': 4, 'updated_at': '2026-04-20T12:00:00Z'},
+                    {'id': 5, 'updated_at': '2026-04-25T12:00:00Z'},
+                ]
+
+                def request_batch_2(url, params=None):
+                    sn = url.rstrip('/').split('/')[-1]
+                    return {sn: batch_2 if sn == stream_name else []}
+
+                written_second = []
+
+                with patch.dict(thf.STATE, state_after_first, clear=True), \
+                     patch.dict(thf.CONFIG, self.default_config.copy(), clear=True), \
+                     patch.object(thf, 'AUTH', self._make_mock_auth()), \
+                     patch.object(thf, 'request', side_effect=request_batch_2), \
+                     patch('singer.write_state'), \
+                     patch('singer.write_schema'), \
+                     patch('singer.write_message',
+                           side_effect=lambda m: written_second.append(m.record)
+                           if hasattr(m, 'record') else None):
+                    thf.do_sync(catalog)
+
+                # All records written in second sync must be >= bookmark
+                for rec in written_second:
+                    rec_dt = singer_utils.strptime_to_utc(rec['updated_at'])
+                    self.assertGreaterEqual(
+                        rec_dt, bookmark_dt,
+                        f"{stream_name}: second sync wrote record with updated_at={rec['updated_at']} "
+                        f"which is before bookmark={bookmark_after_first}",
+                    )

--- a/tests/mock_integration/test_pagination.py
+++ b/tests/mock_integration/test_pagination.py
@@ -1,0 +1,180 @@
+"""Mock integration test: pagination / windowed date ranges — the tap splits
+the date range into 180-day windows and makes a separate request per window,
+deduplicating records that appear in multiple windows."""
+import unittest
+from unittest.mock import patch
+
+import tap_harvest_forecast as thf
+
+from .base import (
+    ALL_STREAM_IDS,
+    HarvestForecastMockBaseTest,
+    STREAM_CONFIG,
+    INCREMENTAL_STREAMS,
+)
+
+
+class PaginationMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def _config_spanning_multiple_windows(self):
+        """Config covering 18 months → at least three 180-day windows."""
+        config = self.default_config.copy()
+        config['start_date'] = '2025-01-01T00:00:00Z'
+        config['end_date'] = '2026-08-01'
+        return config
+
+    def test_requests_include_start_date_and_end_date_params(self):
+        """Every request to the API must include start_date and end_date params."""
+        config = self._config_spanning_multiple_windows()
+        request_calls = []
+
+        def tracking_request(url, params=None):
+            request_calls.append({'url': url, 'params': params or {}})
+            stream_name = url.rstrip('/').split('/')[-1]
+            records = self._get_mock_records(stream_name) if stream_name in STREAM_CONFIG else []
+            return {stream_name: records}
+
+        catalog = self._make_selected_catalog(stream_names=['assignments'])
+        with patch.dict(thf.STATE, {}, clear=True), \
+             patch.dict(thf.CONFIG, config, clear=True), \
+             patch.object(thf, 'AUTH', self._make_mock_auth()), \
+             patch.object(thf, 'request', side_effect=tracking_request), \
+             patch('singer.write_state'), \
+             patch('singer.write_schema'), \
+             patch('singer.write_message'):
+            thf.do_sync(catalog)
+
+        self.assertGreater(len(request_calls), 0, "Expected at least one request")
+        for req in request_calls:
+            self.assertIn('start_date', req['params'],
+                f"Request missing start_date param: {req}")
+            self.assertIn('end_date', req['params'],
+                f"Request missing end_date param: {req}")
+
+    def test_multiple_windows_made_for_wide_date_range(self):
+        """A date range > 180 days must result in more than one request per stream."""
+        config = self._config_spanning_multiple_windows()
+        request_calls = []
+
+        def tracking_request(url, params=None):
+            request_calls.append(url)
+            stream_name = url.rstrip('/').split('/')[-1]
+            records = self._get_mock_records(stream_name) if stream_name in STREAM_CONFIG else []
+            return {stream_name: records}
+
+        catalog = self._make_selected_catalog(stream_names=['assignments'])
+        with patch.dict(thf.STATE, {}, clear=True), \
+             patch.dict(thf.CONFIG, config, clear=True), \
+             patch.object(thf, 'AUTH', self._make_mock_auth()), \
+             patch.object(thf, 'request', side_effect=tracking_request), \
+             patch('singer.write_state'), \
+             patch('singer.write_schema'), \
+             patch('singer.write_message'):
+            thf.do_sync(catalog)
+
+        # ~18 months / 180 days ≈ 3+ windows
+        self.assertGreaterEqual(len(request_calls), 3,
+            f"Expected >= 3 requests for wide date range, got {len(request_calls)}")
+
+    def test_records_are_deduplicated_across_windows(self):
+        """Records whose IDs appear in multiple window responses are written only once."""
+        config = self._config_spanning_multiple_windows()
+        catalog = self._make_selected_catalog(stream_names=['assignments'])
+        records, _ = self.run_sync(catalog, state={}, config=config)
+
+        stream_records = [r for s, r in records if s == 'assignments']
+        ids = [r['id'] for r in stream_records]
+        # No duplicate IDs
+        self.assertEqual(
+            len(ids), len(set(ids)),
+            f"Duplicate record IDs found: {[i for i in ids if ids.count(i) > 1]}",
+        )
+
+    def test_total_unique_records_equals_mock_count(self):
+        """After deduplication, the total records must equal the mock data count."""
+        config = self._config_spanning_multiple_windows()
+
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                records, _ = self.run_sync(catalog, state={}, config=config)
+                stream_records = [r for s, r in records if s == stream]
+                self.assertEqual(
+                    len(stream_records), STREAM_CONFIG[stream]['record_count'],
+                    f"{stream}: expected {STREAM_CONFIG[stream]['record_count']} unique records",
+                )
+
+    def test_sync_uses_date_windows_for_all_streams(self):
+        """Every selected stream must have start_date + end_date on every request.
+        Covers all streams including FULL_TABLE. Ported from previously approved mock test."""
+        config = self._config_spanning_multiple_windows()
+
+        for stream_name in ALL_STREAM_IDS:
+            with self.subTest(stream=stream_name):
+                request_calls = []
+
+                def tracking_request(url, params=None):
+                    request_calls.append({'url': url, 'params': params or {}})
+                    sn = url.rstrip('/').split('/')[-1]
+                    recs = self._get_mock_records(sn) if sn in STREAM_CONFIG else []
+                    return {sn: recs}
+
+                catalog = self._make_selected_catalog(stream_names=[stream_name])
+                with patch.dict(thf.STATE, {}, clear=True), \
+                     patch.dict(thf.CONFIG, config, clear=True), \
+                     patch.object(thf, 'AUTH', self._make_mock_auth()), \
+                     patch.object(thf, 'request', side_effect=tracking_request), \
+                     patch('singer.write_state'), \
+                     patch('singer.write_schema'), \
+                     patch('singer.write_message'):
+                    thf.do_sync(catalog)
+
+                self.assertGreater(len(request_calls), 0,
+                    f"Expected at least one request for {stream_name}")
+                for req in request_calls:
+                    self.assertIn('start_date', req['params'],
+                        f"{stream_name}: request missing start_date param")
+                    self.assertIn('end_date', req['params'],
+                        f"{stream_name}: request missing end_date param")
+
+    def test_sync_handles_different_records_per_window(self):
+        """Records from each window are all collected and written.
+        Ported from previously approved mock test."""
+        stream_name = 'assignments'
+        call_count = [0]
+
+        # Window 1 returns IDs 1 & 2, window 2 returns IDs 3 & 4
+        def windowed_request(url, params=None):
+            call_count[0] += 1
+            sn = url.rstrip('/').split('/')[-1]
+            if call_count[0] == 1:
+                return {sn: [
+                    {'id': 1, 'updated_at': '2025-02-15T12:00:00Z'},
+                    {'id': 2, 'updated_at': '2025-03-15T12:00:00Z'},
+                ]}
+            elif call_count[0] == 2:
+                return {sn: [
+                    {'id': 3, 'updated_at': '2025-08-15T12:00:00Z'},
+                    {'id': 4, 'updated_at': '2025-09-15T12:00:00Z'},
+                ]}
+            return {sn: []}
+
+        config = self._config_spanning_multiple_windows()
+        catalog = self._make_selected_catalog(stream_names=[stream_name])
+
+        written = []
+        with patch.dict(thf.STATE, {}, clear=True), \
+             patch.dict(thf.CONFIG, config, clear=True), \
+             patch.object(thf, 'AUTH', self._make_mock_auth()), \
+             patch.object(thf, 'request', side_effect=windowed_request), \
+             patch('singer.write_state'), \
+             patch('singer.write_schema'), \
+             patch('singer.write_message',
+                   side_effect=lambda m: written.append(m.record) if hasattr(m, 'record') else None):
+            thf.do_sync(catalog)
+
+        self.assertGreater(len(written), 0, "Expected records from multiple windows")
+        written_ids = {r['id'] for r in written}
+        # Records from both windows must be present
+        self.assertTrue({1, 2}.issubset(written_ids),
+            f"Window-1 records missing: {written_ids}")

--- a/tests/mock_integration/test_start_date.py
+++ b/tests/mock_integration/test_start_date.py
@@ -1,0 +1,161 @@
+"""Mock integration test: start_date — records before the configured start
+date are excluded; existing bookmarks override start_date."""
+import unittest
+from unittest.mock import patch
+
+from singer import utils as singer_utils
+
+import tap_harvest_forecast as thf
+
+from .base import (
+    HarvestForecastMockBaseTest,
+    STREAM_CONFIG,
+    INCREMENTAL_STREAMS,
+    FULL_TABLE_STREAMS,
+)
+
+
+class StartDateMockIntegrationTest(HarvestForecastMockBaseTest, unittest.TestCase):
+
+    def test_records_before_start_date_are_excluded(self):
+        """Set start_date to mid-range: only records >= start_date are written."""
+        # Mock records have updated_at: 04-15, 04-16, 04-17 (all at T10:00:00Z)
+        # start_date = 04-16T00:00:00Z -> records on 04-16 and 04-17 survive (2 of 3)
+        start_date = '2026-04-16T00:00:00Z'
+        config = self.default_config.copy()
+        config['start_date'] = start_date
+
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                records, _ = self.run_sync(catalog, state={}, config=config)
+
+                stream_records = [r for s, r in records if s == stream]
+                self.assertGreater(len(stream_records), 0,
+                    f"No records synced for {stream}")
+                for rec in stream_records:
+                    self.assertGreaterEqual(
+                        rec['updated_at'], start_date,
+                        f"{stream}: record updated_at={rec['updated_at']} is before start_date={start_date}",
+                    )
+
+    def test_all_records_synced_when_start_date_before_all_data(self):
+        """A start_date before all mock records should yield all records."""
+        config = self.default_config.copy()
+        config['start_date'] = '2026-01-01T00:00:00Z'
+
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                records, _ = self.run_sync(catalog, state={}, config=config)
+
+                stream_records = [r for s, r in records if s == stream]
+                self.assertEqual(
+                    len(stream_records), STREAM_CONFIG[stream]['record_count'],
+                    f"{stream}: expected {STREAM_CONFIG[stream]['record_count']} records",
+                )
+
+    def test_existing_bookmark_takes_priority_over_start_date(self):
+        """An existing state bookmark overrides start_date."""
+        config = self.default_config.copy()
+        config['start_date'] = '2026-01-01T00:00:00Z'
+
+        bookmark = '2026-04-16T10:00:00Z'
+        for stream in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream):
+                initial_state = {'bookmarks': {stream: {'updated_at': bookmark}}}
+                catalog = self._make_selected_catalog(stream_names=[stream])
+                records, _ = self.run_sync(catalog, state=initial_state, config=config)
+
+                stream_records = [r for s, r in records if s == stream]
+                bookmark_dt = singer_utils.strptime_to_utc(bookmark)
+                for rec in stream_records:
+                    rec_dt = singer_utils.strptime_to_utc(rec['updated_at'])
+                    self.assertGreaterEqual(
+                        rec_dt, bookmark_dt,
+                        f"{stream}: record before bookmark was not filtered",
+                    )
+
+    def test_full_table_streams_ignore_start_date(self):
+        """FULL_TABLE streams should return all records regardless of start_date."""
+        for future_start in ['2025-01-01T00:00:00Z', '2027-01-01T00:00:00Z']:
+            config = self.default_config.copy()
+            config['start_date'] = future_start
+            config['end_date'] = '2027-12-31'
+
+            for stream in FULL_TABLE_STREAMS:
+                with self.subTest(stream=stream, start=future_start):
+                    catalog = self._make_selected_catalog(stream_names=[stream])
+                    records, _ = self.run_sync(catalog, state={}, config=config)
+                    stream_records = [r for s, r in records if s == stream]
+                    # All records written regardless of start_date
+                    self.assertEqual(
+                        len(stream_records), STREAM_CONFIG[stream]['record_count'],
+                        f"{stream}: expected all {STREAM_CONFIG[stream]['record_count']} records",
+                    )
+
+    def test_different_start_dates_produce_different_record_counts(self):
+        """Records synced shrink as start_date moves forward through the data range."""
+        stream = 'assignments'
+        catalog = self._make_selected_catalog(stream_names=[stream])
+
+        config_early = self.default_config.copy()
+        config_early['start_date'] = '2026-01-01T00:00:00Z'
+        records_early, _ = self.run_sync(catalog, state={}, config=config_early)
+        count_early = len([r for s, r in records_early if s == stream])
+
+        config_late = self.default_config.copy()
+        config_late['start_date'] = '2026-04-17T00:00:00Z'
+        records_late, _ = self.run_sync(catalog, state={}, config=config_late)
+        count_late = len([r for s, r in records_late if s == stream])
+
+        self.assertGreater(count_early, count_late,
+            "Earlier start_date should produce more records than later start_date")
+
+    def test_start_date_becomes_initial_bookmark(self):
+        """Verify get_start() returns config start_date when no state exists."""
+
+        start_date = '2026-03-01T00:00:00Z'
+        config = self.default_config.copy()
+        config['start_date'] = start_date
+
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                with patch.dict(thf.STATE, {}, clear=True), \
+                     patch.dict(thf.CONFIG, config, clear=True):
+                    result = thf.get_start(stream_name)
+                self.assertEqual(result, start_date,
+                    f"{stream_name}: get_start should return config start_date when state is empty")
+
+    def test_empty_state_uses_config_start_date(self):
+        """Verify get_start() falls back to CONFIG['start_date'] with empty STATE."""
+
+        start_date = '2026-01-01T00:00:00Z'
+        config = self.default_config.copy()
+        config['start_date'] = start_date
+
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                with patch.dict(thf.STATE, {}, clear=True), \
+                     patch.dict(thf.CONFIG, config, clear=True):
+                    result = thf.get_start(stream_name)
+                self.assertEqual(result, start_date)
+
+    def test_bookmark_overrides_start_date(self):
+        """Verify existing bookmark takes precedence over config start_date."""
+
+        start_date = '2026-01-01T00:00:00Z'
+        bookmark_date = '2026-04-15T10:00:00Z'
+        config = self.default_config.copy()
+        config['start_date'] = start_date
+
+        for stream_name in INCREMENTAL_STREAMS:
+            with self.subTest(stream=stream_name):
+                nested_state = {
+                    'bookmarks': {stream_name: {'updated_at': bookmark_date}}
+                }
+                with patch.dict(thf.STATE, nested_state, clear=True), \
+                     patch.dict(thf.CONFIG, config, clear=True):
+                    result = thf.get_start(stream_name)
+                self.assertEqual(result, bookmark_date,
+                    f"{stream_name}: get_start should return bookmark, not config start_date")

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,82 +1,18 @@
-"""Integration tests for tap-harvest-forecast all fields replication with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
+"""Test that all fields are replicated for each stream."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.all_fields_test import AllFieldsTest
 
 
-class HarvestForecastAllFieldsTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that all fields from schemas are replicated when selected."""
+class HarvestForecastAllFieldsTest(AllFieldsTest, HarvestForecastBaseTest):
+    """Ensure running the tap with all streams and fields selected results in
+    the replication of all fields."""
+    MISSING_FIELDS = {}
 
-    def test_all_schema_fields_are_present_in_records(self):
-        """Verify that mock records contain all fields defined in schemas."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Load the schema
-                schema = self.load_schema(stream_name)
-                schema_fields = set(schema.get("properties", {}).keys())
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_all_fields_test"
 
-                # Generate a mock record
-                mock_record = self._generate_stream_record(stream_name)
-                record_fields = set(mock_record.keys())
-
-                # Find fields in schema but not in mock record
-                missing_fields = schema_fields - record_fields
-
-                # Some fields might legitimately be absent if they're optional/nullable
-                # For now, just verify that key fields are present
-                required_fields = {"id", "updated_at"}
-                self.assertTrue(
-                    required_fields.issubset(record_fields),
-                    f"Stream {stream_name} mock record missing required fields: {required_fields - record_fields}"
-                )
-
-    def test_sync_outputs_all_record_fields(self):
-        """Verify that sync includes all fields from the mock records."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Create a mock record with all fields
-                records = [self._generate_stream_record(stream_name, 1)]
-                expected_fields = set(records[0].keys())
-
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                from singer.catalog import Catalog
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify at least one record was written
-                self.assertGreater(len(written_records), 0,
-                    f"Expected records to be written for {stream_name}")
-
-                # Check that written records have the expected fields
-                for record in written_records:
-                    actual_fields = set(record.keys())
-                    # All fields in original record should be in output
-                    self.assertTrue(
-                        expected_fields.issubset(actual_fields),
-                        f"Written record missing fields: {expected_fields - actual_fields}"
-                    )
+    def streams_to_test(self):
+        # Exclude streams where test data is not available
+        streams_to_exclude = {}
+        return self.expected_stream_names().difference(streams_to_exclude)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,0 +1,82 @@
+"""Integration tests for tap-harvest-forecast all fields replication with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+
+
+class HarvestForecastAllFieldsTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that all fields from schemas are replicated when selected."""
+
+    def test_all_schema_fields_are_present_in_records(self):
+        """Verify that mock records contain all fields defined in schemas."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Load the schema
+                schema = self.load_schema(stream_name)
+                schema_fields = set(schema.get("properties", {}).keys())
+
+                # Generate a mock record
+                mock_record = self._generate_stream_record(stream_name)
+                record_fields = set(mock_record.keys())
+
+                # Find fields in schema but not in mock record
+                missing_fields = schema_fields - record_fields
+
+                # Some fields might legitimately be absent if they're optional/nullable
+                # For now, just verify that key fields are present
+                required_fields = {"id", "updated_at"}
+                self.assertTrue(
+                    required_fields.issubset(record_fields),
+                    f"Stream {stream_name} mock record missing required fields: {required_fields - record_fields}"
+                )
+
+    def test_sync_outputs_all_record_fields(self):
+        """Verify that sync includes all fields from the mock records."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Create a mock record with all fields
+                records = [self._generate_stream_record(stream_name, 1)]
+                expected_fields = set(records[0].keys())
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                from singer.catalog import Catalog
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify at least one record was written
+                self.assertGreater(len(written_records), 0,
+                    f"Expected records to be written for {stream_name}")
+
+                # Check that written records have the expected fields
+                for record in written_records:
+                    actual_fields = set(record.keys())
+                    # All fields in original record should be in output
+                    self.assertTrue(
+                        expected_fields.issubset(actual_fields),
+                        f"Written record missing fields: {expected_fields - actual_fields}"
+                    )

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,146 +1,19 @@
-"""Integration tests for tap-harvest-forecast automatic fields with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-from singer.catalog import Catalog
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
+"""Test that with no fields selected for a stream automatic fields are still replicated."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.automatic_fields_test import MinimumSelectionTest
 
 
-class HarvestForecastAutomaticFieldsTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that automatic fields (primary & replication keys) are always replicated."""
+class HarvestForecastAutomaticFieldsTest(MinimumSelectionTest, HarvestForecastBaseTest):
+    """Test that with no fields selected for a stream automatic fields are
+    still replicated."""
 
-    def test_automatic_fields_always_present(self):
-        """Verify primary and replication keys are present even with no field selection."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                records = [self._generate_stream_record(stream_name, 1)]
-                mock_request = MagicMock(return_value={stream_name: records})
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_automatic_fields_test"
 
-                # Create catalog with stream selected but no specific fields selected
-                # (simulating automatic-only field selection)
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify records were written
-                self.assertGreater(len(written_records), 0,
-                    f"Expected records to be written for {stream_name}")
-
-                # Verify automatic fields are present
-                expected_automatic = (
-                    self.EXPECTED_METADATA[stream_name]["primary_keys"] |
-                    self.EXPECTED_METADATA[stream_name]["replication_keys"]
-                )
-
-                for record in written_records:
-                    actual_fields = set(record.keys())
-                    self.assertTrue(
-                        expected_automatic.issubset(actual_fields),
-                        f"Automatic fields {expected_automatic} not all present in record. "
-                        f"Found: {actual_fields}"
-                    )
-
-    def test_primary_key_always_populated(self):
-        """Verify primary key field is never null."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                records = [
-                    self._generate_stream_record(stream_name, 1),
-                    self._generate_stream_record(stream_name, 2),
-                    self._generate_stream_record(stream_name, 3),
-                ]
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Get primary key field name
-                primary_key = next(iter(self.EXPECTED_METADATA[stream_name]["primary_keys"]))
-
-                # Verify all records have non-null primary key
-                for record in written_records:
-                    self.assertIn(primary_key, record,
-                        f"Primary key '{primary_key}' missing from record")
-                    self.assertIsNotNone(record[primary_key],
-                        f"Primary key '{primary_key}' should not be null")
-
-    def test_replication_key_always_populated(self):
-        """Verify replication key field is never null."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                records = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 2, "2024-03-16T12:00:00Z"),
-                ]
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Get replication key field name
-                replication_key = next(iter(self.EXPECTED_METADATA[stream_name]["replication_keys"]))
-
-                # Verify all records have non-null replication key
-                for record in written_records:
-                    self.assertIn(replication_key, record,
-                        f"Replication key '{replication_key}' missing from record")
-                    self.assertIsNotNone(record[replication_key],
-                        f"Replication key '{replication_key}' should not be null")
+    def streams_to_test(self):
+        # Exclude streams where test data is not available
+        streams_to_exclude = {
+            'roles',
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,0 +1,146 @@
+"""Integration tests for tap-harvest-forecast automatic fields with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+from singer.catalog import Catalog
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+
+
+class HarvestForecastAutomaticFieldsTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that automatic fields (primary & replication keys) are always replicated."""
+
+    def test_automatic_fields_always_present(self):
+        """Verify primary and replication keys are present even with no field selection."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                records = [self._generate_stream_record(stream_name, 1)]
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                # Create catalog with stream selected but no specific fields selected
+                # (simulating automatic-only field selection)
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify records were written
+                self.assertGreater(len(written_records), 0,
+                    f"Expected records to be written for {stream_name}")
+
+                # Verify automatic fields are present
+                expected_automatic = (
+                    self.EXPECTED_METADATA[stream_name]["primary_keys"] |
+                    self.EXPECTED_METADATA[stream_name]["replication_keys"]
+                )
+
+                for record in written_records:
+                    actual_fields = set(record.keys())
+                    self.assertTrue(
+                        expected_automatic.issubset(actual_fields),
+                        f"Automatic fields {expected_automatic} not all present in record. "
+                        f"Found: {actual_fields}"
+                    )
+
+    def test_primary_key_always_populated(self):
+        """Verify primary key field is never null."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                records = [
+                    self._generate_stream_record(stream_name, 1),
+                    self._generate_stream_record(stream_name, 2),
+                    self._generate_stream_record(stream_name, 3),
+                ]
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Get primary key field name
+                primary_key = next(iter(self.EXPECTED_METADATA[stream_name]["primary_keys"]))
+
+                # Verify all records have non-null primary key
+                for record in written_records:
+                    self.assertIn(primary_key, record,
+                        f"Primary key '{primary_key}' missing from record")
+                    self.assertIsNotNone(record[primary_key],
+                        f"Primary key '{primary_key}' should not be null")
+
+    def test_replication_key_always_populated(self):
+        """Verify replication key field is never null."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                records = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 2, "2024-03-16T12:00:00Z"),
+                ]
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Get replication key field name
+                replication_key = next(iter(self.EXPECTED_METADATA[stream_name]["replication_keys"]))
+
+                # Verify all records have non-null replication key
+                for record in written_records:
+                    self.assertIn(replication_key, record,
+                        f"Replication key '{replication_key}' missing from record")
+                    self.assertIsNotNone(record[replication_key],
+                        f"Replication key '{replication_key}' should not be null")

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,148 +1,43 @@
-"""Integration tests for tap-harvest-forecast bookmarking with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-from singer.catalog import Catalog
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
-from singer import utils
+"""Test tap sets a bookmark and respects it for the next sync of a stream."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
 
 
-class HarvestForecastBookmarkTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that bookmarks are set and respected correctly."""
+class HarvestForecastBookmarkTest(BookmarkTest, HarvestForecastBaseTest):
+    """Test tap sets a bookmark and respects it for the next sync of a stream."""
 
-    def test_bookmark_is_set_during_sync(self):
-        """Verify that bookmarks are written to state during sync."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Create mock records with different updated_at values
-                records = [
-                    self._generate_stream_record(stream_name, i, f"2024-03-{i:02d}T12:00:00Z")
-                    for i in range(1, 4)
-                ]
+    start_date = "2026-03-01T00:00:00Z"
+    bookmark_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
-                # Mock the request function
-                mock_request = MagicMock(return_value={stream_name: records})
+    initial_bookmarks = {
+        "bookmarks": {
+            "assignments": {"updated_at": "2026-03-20T00:00:00Z"},
+            "clients": {"updated_at": "2026-04-25T00:00:00Z"},
+        }
+    }
 
-                # Mock catalog with this stream selected
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_bookmark_test"
 
-                # Capture written messages
-                written_messages = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    written_messages.append(msg)
-                    return original_write_message(msg)
+    def streams_to_test(self):
+        # Exclude roles stream as it's missing updated_at field in data.
+        # Exclude milestones, people, projects as all records share the same
+        # updated_at value, making it impossible for sync 2 to return fewer
+        # records than sync 1 (required by test_first_vs_second_records).
+        streams_to_exclude = {
+            'roles',
+            'milestones',
+            'people',
+            'projects'
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    # Run sync
-                    tap_harvest_forecast.do_sync(catalog)
-
-                    # Verify STATE was updated with bookmark (must be inside patch context)
-                    self.assertIn(stream_name, tap_harvest_forecast.STATE)
-                    bookmark_value = tap_harvest_forecast.STATE[stream_name]
-
-                    # Bookmark should be set to the last record's updated_at
-                    self.assertIsNotNone(bookmark_value)
-
-    def test_bookmark_filters_records(self):
-        """Verify that records are filtered based on existing bookmark."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Create records: before, at, and after bookmark date
-                bookmark_date = "2024-03-15T12:00:00Z"
-                records = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),  # Before bookmark
-                    self._generate_stream_record(stream_name, 2, "2024-03-15T12:00:00Z"),  # At bookmark
-                    self._generate_stream_record(stream_name, 3, "2024-03-20T12:00:00Z"),  # After bookmark
-                ]
-
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                # Set initial bookmark
-                initial_state = {stream_name: bookmark_date}
-
-                # Capture written record messages
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', initial_state.copy()), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify that only records >= bookmark were written
-                written_ids = {r["id"] for r in written_records}
-
-                # Record 1 (before bookmark) should not be included
-                self.assertNotIn(1, written_ids,
-                    "Record before bookmark should be filtered out")
-                # Records 2 and 3 (at/after bookmark) should be included
-                self.assertGreater(len(written_records), 0, "Expected some records to be synced")
-
-    def test_bookmark_advances_to_latest_record(self):
-        """Verify bookmark advances to the most recent record's updated_at."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Records with progressively later timestamps
-                latest_date = "2024-03-25T12:00:00Z"
-                records = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-20T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 2, "2024-03-22T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 3, latest_date),
-                ]
-
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                initial_bookmark = "2024-03-01T12:00:00Z"
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {stream_name: initial_bookmark}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                    # Bookmark should have advanced to the latest record (must be inside patch context)
-                    final_bookmark = tap_harvest_forecast.STATE.get(stream_name)
-                    self.assertIsNotNone(final_bookmark)
-
-                    # Parse and compare dates
-                    final_dt = utils.strptime_to_utc(final_bookmark)
-                    latest_dt = utils.strptime_to_utc(latest_date)
-
-                    self.assertGreaterEqual(final_dt, latest_dt,
-                        f"Bookmark should have advanced to {latest_date} but is {final_bookmark}"
-                    )
+    def calculate_new_bookmarks(self):
+        """Calculates new bookmarks that will result in some records being
+        synced in sync 2 (plus any necessary look back data)."""
+        new_bookmarks = {
+            "assignments": {"updated_at": "2026-04-15T00:00:00Z"},
+            "clients": {"updated_at": "2026-05-01T00:00:00Z"},
+        }
+        return new_bookmarks

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,0 +1,148 @@
+"""Integration tests for tap-harvest-forecast bookmarking with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+from singer.catalog import Catalog
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+from singer import utils
+
+
+class HarvestForecastBookmarkTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that bookmarks are set and respected correctly."""
+
+    def test_bookmark_is_set_during_sync(self):
+        """Verify that bookmarks are written to state during sync."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Create mock records with different updated_at values
+                records = [
+                    self._generate_stream_record(stream_name, i, f"2024-03-{i:02d}T12:00:00Z")
+                    for i in range(1, 4)
+                ]
+
+                # Mock the request function
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                # Mock catalog with this stream selected
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                # Capture written messages
+                written_messages = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    written_messages.append(msg)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    # Run sync
+                    tap_harvest_forecast.do_sync(catalog)
+
+                    # Verify STATE was updated with bookmark (must be inside patch context)
+                    self.assertIn(stream_name, tap_harvest_forecast.STATE)
+                    bookmark_value = tap_harvest_forecast.STATE[stream_name]
+
+                    # Bookmark should be set to the last record's updated_at
+                    self.assertIsNotNone(bookmark_value)
+
+    def test_bookmark_filters_records(self):
+        """Verify that records are filtered based on existing bookmark."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Create records: before, at, and after bookmark date
+                bookmark_date = "2024-03-15T12:00:00Z"
+                records = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),  # Before bookmark
+                    self._generate_stream_record(stream_name, 2, "2024-03-15T12:00:00Z"),  # At bookmark
+                    self._generate_stream_record(stream_name, 3, "2024-03-20T12:00:00Z"),  # After bookmark
+                ]
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                # Set initial bookmark
+                initial_state = {stream_name: bookmark_date}
+
+                # Capture written record messages
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', initial_state.copy()), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify that only records >= bookmark were written
+                written_ids = {r["id"] for r in written_records}
+
+                # Record 1 (before bookmark) should not be included
+                self.assertNotIn(1, written_ids,
+                    "Record before bookmark should be filtered out")
+                # Records 2 and 3 (at/after bookmark) should be included
+                self.assertGreater(len(written_records), 0, "Expected some records to be synced")
+
+    def test_bookmark_advances_to_latest_record(self):
+        """Verify bookmark advances to the most recent record's updated_at."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Records with progressively later timestamps
+                latest_date = "2024-03-25T12:00:00Z"
+                records = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-20T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 2, "2024-03-22T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 3, latest_date),
+                ]
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                initial_bookmark = "2024-03-01T12:00:00Z"
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {stream_name: initial_bookmark}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                    # Bookmark should have advanced to the latest record (must be inside patch context)
+                    final_bookmark = tap_harvest_forecast.STATE.get(stream_name)
+                    self.assertIsNotNone(final_bookmark)
+
+                    # Parse and compare dates
+                    final_dt = utils.strptime_to_utc(final_bookmark)
+                    latest_dt = utils.strptime_to_utc(latest_date)
+
+                    self.assertGreaterEqual(final_dt, latest_dt,
+                        f"Bookmark should have advanced to {latest_date} but is {final_bookmark}"
+                    )

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,126 +1,14 @@
-"""Integration tests for tap-harvest-forecast stream discovery with mocked data."""
-import io
-import json
-import unittest
-from unittest.mock import patch
-from contextlib import redirect_stdout
-from singer import metadata
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
+"""Test tap discovery mode and metadata."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
 
 
-class HarvestForecastDiscoveryTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test discovery mode returns valid catalog with proper metadata."""
+class HarvestForecastDiscoveryTest(DiscoveryTest, HarvestForecastBaseTest):
+    """Test tap discovery mode and metadata conforms to standards."""
 
-    def test_discovery_returns_expected_streams(self):
-        """Verify all expected streams are discovered."""
-        # Patch CONFIG to avoid auth requirement
-        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
-            # Call do_discover which writes to stdout
-            import sys
-            output = io.StringIO()
-            with redirect_stdout(output):
-                tap_harvest_forecast.do_discover()
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_discovery_test"
 
-            # Parse the output
-            catalog = json.loads(output.getvalue())
-
-            # Verify catalog structure
-            self.assertIn("streams", catalog)
-            self.assertIsInstance(catalog["streams"], list)
-
-            # Get stream names from catalog
-            stream_names = {stream["stream"] for stream in catalog["streams"]}
-
-            # Verify all expected streams are present
-            self.assertEqual(self.EXPECTED_STREAMS, stream_names)
-
-    def test_discovery_metadata_includes_keys(self):
-        """Verify each stream has proper metadata for keys and replication."""
-        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
-            output = io.StringIO()
-            with redirect_stdout(output):
-                tap_harvest_forecast.do_discover()
-
-            catalog = json.loads(output.getvalue())
-
-            for stream_entry in catalog["streams"]:
-                stream_name = stream_entry["stream"]
-                stream_metadata = metadata.to_map(stream_entry["metadata"])
-
-                # Verify table-key-properties exist
-                table_keys = metadata.get(stream_metadata, (), "table-key-properties")
-                self.assertIsNotNone(table_keys, f"Stream {stream_name} missing table-key-properties")
-                self.assertEqual(
-                    set(table_keys),
-                    self.EXPECTED_METADATA[stream_name]["primary_keys"],
-                    f"Stream {stream_name} has incorrect primary keys"
-                )
-
-                # Verify valid-replication-keys exist
-                replication_keys = metadata.get(stream_metadata, (), "valid-replication-keys")
-                self.assertIsNotNone(replication_keys, f"Stream {stream_name} missing replication keys")
-                self.assertEqual(
-                    set(replication_keys),
-                    self.EXPECTED_METADATA[stream_name]["replication_keys"],
-                    f"Stream {stream_name} has incorrect replication keys"
-                )
-
-    def test_discovery_automatic_fields(self):
-        """Verify primary and replication keys are marked as automatic."""
-        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
-            output = io.StringIO()
-            with redirect_stdout(output):
-                tap_harvest_forecast.do_discover()
-
-            catalog = json.loads(output.getvalue())
-
-            for stream_entry in catalog["streams"]:
-                stream_name = stream_entry["stream"]
-                stream_metadata = metadata.to_map(stream_entry["metadata"])
-
-                # Get automatic fields (primary + replication keys)
-                expected_automatic = (
-                    self.EXPECTED_METADATA[stream_name]["primary_keys"] |
-                    self.EXPECTED_METADATA[stream_name]["replication_keys"]
-                )
-
-                # Verify each automatic field has inclusion=automatic
-                for field_name in expected_automatic:
-                    inclusion = metadata.get(
-                        stream_metadata,
-                        ("properties", field_name),
-                        "inclusion"
-                    )
-                    self.assertEqual(
-                        inclusion,
-                        "automatic",
-                        f"Field {field_name} in {stream_name} should be automatic"
-                    )
-
-    def test_discovery_schemas_are_valid(self):
-        """Verify each stream's schema is a valid JSON schema."""
-        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
-            output = io.StringIO()
-            with redirect_stdout(output):
-                tap_harvest_forecast.do_discover()
-
-            catalog = json.loads(output.getvalue())
-
-            for stream_entry in catalog["streams"]:
-                stream_name = stream_entry["stream"]
-                schema = stream_entry["schema"]
-
-                # Verify basic schema structure
-                self.assertIn("type", schema, f"{stream_name} schema missing 'type'")
-                self.assertIn("properties", schema, f"{stream_name} schema missing 'properties'")
-                self.assertIsInstance(schema["properties"], dict)
-
-                # Verify id and updated_at are in schema
-                self.assertIn("id", schema["properties"], f"{stream_name} missing 'id' in schema")
-                self.assertIn("updated_at", schema["properties"], f"{stream_name} missing 'updated_at' in schema")
+    def streams_to_test(self):
+        return self.expected_stream_names()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,126 @@
+"""Integration tests for tap-harvest-forecast stream discovery with mocked data."""
+import io
+import json
+import unittest
+from unittest.mock import patch
+from contextlib import redirect_stdout
+from singer import metadata
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+
+
+class HarvestForecastDiscoveryTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test discovery mode returns valid catalog with proper metadata."""
+
+    def test_discovery_returns_expected_streams(self):
+        """Verify all expected streams are discovered."""
+        # Patch CONFIG to avoid auth requirement
+        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
+            # Call do_discover which writes to stdout
+            import sys
+            output = io.StringIO()
+            with redirect_stdout(output):
+                tap_harvest_forecast.do_discover()
+
+            # Parse the output
+            catalog = json.loads(output.getvalue())
+
+            # Verify catalog structure
+            self.assertIn("streams", catalog)
+            self.assertIsInstance(catalog["streams"], list)
+
+            # Get stream names from catalog
+            stream_names = {stream["stream"] for stream in catalog["streams"]}
+
+            # Verify all expected streams are present
+            self.assertEqual(self.EXPECTED_STREAMS, stream_names)
+
+    def test_discovery_metadata_includes_keys(self):
+        """Verify each stream has proper metadata for keys and replication."""
+        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                tap_harvest_forecast.do_discover()
+
+            catalog = json.loads(output.getvalue())
+
+            for stream_entry in catalog["streams"]:
+                stream_name = stream_entry["stream"]
+                stream_metadata = metadata.to_map(stream_entry["metadata"])
+
+                # Verify table-key-properties exist
+                table_keys = metadata.get(stream_metadata, (), "table-key-properties")
+                self.assertIsNotNone(table_keys, f"Stream {stream_name} missing table-key-properties")
+                self.assertEqual(
+                    set(table_keys),
+                    self.EXPECTED_METADATA[stream_name]["primary_keys"],
+                    f"Stream {stream_name} has incorrect primary keys"
+                )
+
+                # Verify valid-replication-keys exist
+                replication_keys = metadata.get(stream_metadata, (), "valid-replication-keys")
+                self.assertIsNotNone(replication_keys, f"Stream {stream_name} missing replication keys")
+                self.assertEqual(
+                    set(replication_keys),
+                    self.EXPECTED_METADATA[stream_name]["replication_keys"],
+                    f"Stream {stream_name} has incorrect replication keys"
+                )
+
+    def test_discovery_automatic_fields(self):
+        """Verify primary and replication keys are marked as automatic."""
+        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                tap_harvest_forecast.do_discover()
+
+            catalog = json.loads(output.getvalue())
+
+            for stream_entry in catalog["streams"]:
+                stream_name = stream_entry["stream"]
+                stream_metadata = metadata.to_map(stream_entry["metadata"])
+
+                # Get automatic fields (primary + replication keys)
+                expected_automatic = (
+                    self.EXPECTED_METADATA[stream_name]["primary_keys"] |
+                    self.EXPECTED_METADATA[stream_name]["replication_keys"]
+                )
+
+                # Verify each automatic field has inclusion=automatic
+                for field_name in expected_automatic:
+                    inclusion = metadata.get(
+                        stream_metadata,
+                        ("properties", field_name),
+                        "inclusion"
+                    )
+                    self.assertEqual(
+                        inclusion,
+                        "automatic",
+                        f"Field {field_name} in {stream_name} should be automatic"
+                    )
+
+    def test_discovery_schemas_are_valid(self):
+        """Verify each stream's schema is a valid JSON schema."""
+        with patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG):
+            output = io.StringIO()
+            with redirect_stdout(output):
+                tap_harvest_forecast.do_discover()
+
+            catalog = json.loads(output.getvalue())
+
+            for stream_entry in catalog["streams"]:
+                stream_name = stream_entry["stream"]
+                schema = stream_entry["schema"]
+
+                # Verify basic schema structure
+                self.assertIn("type", schema, f"{stream_name} schema missing 'type'")
+                self.assertIn("properties", schema, f"{stream_name} schema missing 'properties'")
+                self.assertIsInstance(schema["properties"], dict)
+
+                # Verify id and updated_at are in schema
+                self.assertIn("id", schema["properties"], f"{stream_name} missing 'id' in schema")
+                self.assertIn("updated_at", schema["properties"], f"{stream_name} missing 'updated_at' in schema")

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -1,152 +1,36 @@
-"""Integration tests for tap-harvest-forecast interrupted sync resumption with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
-from singer import utils
-from singer.catalog import Catalog
+"""Test tap can resume from an interrupted sync."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.interrupted_sync_test import InterruptedSyncTest
 
 
-class HarvestForecastInterruptedSyncTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that interrupted syncs can resume from the last bookmark."""
+class HarvestForecastInterruptedSyncTest(InterruptedSyncTest, HarvestForecastBaseTest):
+    """Test tap sets a bookmark and respects it for the next sync of a stream."""
 
-    def test_sync_resumes_from_last_bookmark_on_interruption(self):
-        """Verify that if sync is interrupted, it resumes from the last written bookmark."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Simulate a scenario where sync writes some records and updates state,
-                # then gets interrupted before completing all records
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_interrupted_sync_test"
 
-                records_batch_1 = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 2, "2024-03-12T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 3, "2024-03-15T12:00:00Z"),  # Last successful
-                ]
+    def streams_to_test(self):
+        # Exclude roles stream as it's missing updated_at field in data
+        # assignments, milestones: API date-range param filters by activity dates
+        # independently of updated_at.
+        streams_to_exclude = {
+            "roles",
+            "assignments",
+            "milestones"
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
-                records_batch_2 = [
-                    self._generate_stream_record(stream_name, 3, "2024-03-15T12:00:00Z"),  # Overlap
-                    self._generate_stream_record(stream_name, 4, "2024-03-20T12:00:00Z"),
-                    self._generate_stream_record(stream_name, 5, "2024-03-25T12:00:00Z"),
-                ]
+    def manipulate_state(self):
+        """Manipulate state to simulate an interrupted sync.
 
-                # First sync: partial sync that writes state
-                mock_request_1 = MagicMock(return_value={stream_name: records_batch_1})
-
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                # Track state updates
-                state_after_first_sync = {}
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request_1), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )):
-
-                    # Run first sync
-                    tap_harvest_forecast.do_sync(catalog)
-
-                    # Capture the state after first sync
-                    state_after_first_sync = tap_harvest_forecast.STATE.copy()
-
-                # Verify state was updated after first sync
-                self.assertIn(stream_name, state_after_first_sync,
-                    f"State should be updated for {stream_name} after first sync")
-
-                bookmark_after_first = state_after_first_sync[stream_name]
-                bookmark_dt = utils.strptime_to_utc(bookmark_after_first)
-
-                # Second sync: resume with the bookmark from first sync
-                mock_request_2 = MagicMock(return_value={stream_name: records_batch_2})
-
-                written_records_second_sync = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records_second_sync.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request_2), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', state_after_first_sync), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    # Run second sync
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify second sync only processes records >= the bookmark
-                for record in written_records_second_sync:
-                    record_dt = utils.strptime_to_utc(record["updated_at"])
-                    self.assertGreaterEqual(
-                        record_dt, bookmark_dt,
-                        f"Second sync should only process records >= bookmark {bookmark_after_first}, "
-                        f"but found record with updated_at={record['updated_at']}"
-                    )
-
-    def test_state_update_frequency_during_sync(self):
-        """Verify that state is updated periodically during sync, not just at the end."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Create multiple records spanning different dates
-                records = [
-                    self._generate_stream_record(stream_name, i, f"2024-03-{10+i:02d}T12:00:00Z")
-                    for i in range(1, 6)
-                ]
-
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                # Track state updates
-                state_snapshots = []
-
-                original_update_state = tap_harvest_forecast.utils.update_state
-                def capture_state_update(state, stream, value):
-                    result = original_update_state(state, stream, value)
-                    # Take a snapshot of the state after each update
-                    state_snapshots.append({
-                        "stream": stream,
-                        "value": str(value),
-                        "state_copy": state.copy()
-                    })
-                    return result
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.utils, 'update_state', side_effect=capture_state_update):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify state was updated multiple times during sync (once per record)
-                stream_updates = [s for s in state_snapshots if s["stream"] == stream_name]
-                self.assertGreater(len(stream_updates), 0,
-                    f"State should be updated during sync for {stream_name}")
-
-                # Verify state values are progressing forward
-                if len(stream_updates) > 1:
-                    for i in range(1, len(stream_updates)):
-                        prev_value = utils.strptime_to_utc(stream_updates[i-1]["value"])
-                        curr_value = utils.strptime_to_utc(stream_updates[i]["value"])
-                        self.assertGreaterEqual(
-                            curr_value, prev_value,
-                            "State should progress forward (or stay same) with each update"
-                        )
+        Sets the currently_syncing stream and partial bookmarks to test
+        that the tap can resume from where it left off.
+        """
+        return {
+            "currently_syncing": "people",
+            "bookmarks": {
+                "clients": {"updated_at": "2026-05-06T00:00:00Z"},
+                "people": {"updated_at": "2026-05-06T00:00:00Z"},
+            }
+        }

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -1,0 +1,152 @@
+"""Integration tests for tap-harvest-forecast interrupted sync resumption with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+from singer import utils
+from singer.catalog import Catalog
+
+
+class HarvestForecastInterruptedSyncTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that interrupted syncs can resume from the last bookmark."""
+
+    def test_sync_resumes_from_last_bookmark_on_interruption(self):
+        """Verify that if sync is interrupted, it resumes from the last written bookmark."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Simulate a scenario where sync writes some records and updates state,
+                # then gets interrupted before completing all records
+
+                records_batch_1 = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 2, "2024-03-12T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 3, "2024-03-15T12:00:00Z"),  # Last successful
+                ]
+
+                records_batch_2 = [
+                    self._generate_stream_record(stream_name, 3, "2024-03-15T12:00:00Z"),  # Overlap
+                    self._generate_stream_record(stream_name, 4, "2024-03-20T12:00:00Z"),
+                    self._generate_stream_record(stream_name, 5, "2024-03-25T12:00:00Z"),
+                ]
+
+                # First sync: partial sync that writes state
+                mock_request_1 = MagicMock(return_value={stream_name: records_batch_1})
+
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                # Track state updates
+                state_after_first_sync = {}
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request_1), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )):
+
+                    # Run first sync
+                    tap_harvest_forecast.do_sync(catalog)
+
+                    # Capture the state after first sync
+                    state_after_first_sync = tap_harvest_forecast.STATE.copy()
+
+                # Verify state was updated after first sync
+                self.assertIn(stream_name, state_after_first_sync,
+                    f"State should be updated for {stream_name} after first sync")
+
+                bookmark_after_first = state_after_first_sync[stream_name]
+                bookmark_dt = utils.strptime_to_utc(bookmark_after_first)
+
+                # Second sync: resume with the bookmark from first sync
+                mock_request_2 = MagicMock(return_value={stream_name: records_batch_2})
+
+                written_records_second_sync = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records_second_sync.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request_2), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', state_after_first_sync), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    # Run second sync
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify second sync only processes records >= the bookmark
+                for record in written_records_second_sync:
+                    record_dt = utils.strptime_to_utc(record["updated_at"])
+                    self.assertGreaterEqual(
+                        record_dt, bookmark_dt,
+                        f"Second sync should only process records >= bookmark {bookmark_after_first}, "
+                        f"but found record with updated_at={record['updated_at']}"
+                    )
+
+    def test_state_update_frequency_during_sync(self):
+        """Verify that state is updated periodically during sync, not just at the end."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Create multiple records spanning different dates
+                records = [
+                    self._generate_stream_record(stream_name, i, f"2024-03-{10+i:02d}T12:00:00Z")
+                    for i in range(1, 6)
+                ]
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                # Track state updates
+                state_snapshots = []
+
+                original_update_state = tap_harvest_forecast.utils.update_state
+                def capture_state_update(state, stream, value):
+                    result = original_update_state(state, stream, value)
+                    # Take a snapshot of the state after each update
+                    state_snapshots.append({
+                        "stream": stream,
+                        "value": str(value),
+                        "state_copy": state.copy()
+                    })
+                    return result
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.utils, 'update_state', side_effect=capture_state_update):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify state was updated multiple times during sync (once per record)
+                stream_updates = [s for s in state_snapshots if s["stream"] == stream_name]
+                self.assertGreater(len(stream_updates), 0,
+                    f"State should be updated during sync for {stream_name}")
+
+                # Verify state values are progressing forward
+                if len(stream_updates) > 1:
+                    for i in range(1, len(stream_updates)):
+                        prev_value = utils.strptime_to_utc(stream_updates[i-1]["value"])
+                        curr_value = utils.strptime_to_utc(stream_updates[i]["value"])
+                        self.assertGreaterEqual(
+                            curr_value, prev_value,
+                            "State should progress forward (or stay same) with each update"
+                        )

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,157 @@
+"""Integration tests for tap-harvest-forecast pagination with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+from singer.catalog import Catalog
+
+
+class HarvestForecastPaginationTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that the tap properly handles pagination through windowed date ranges."""
+
+    def test_sync_uses_date_windows(self):
+        """Verify that sync requests data in 180-day windows."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Track all request calls
+                request_calls = []
+
+                def mock_request_fn(url, params=None):
+                    request_calls.append({"url": url, "params": params})
+                    # Return empty results
+                    return {stream_name: []}
+
+                mock_request = MagicMock(side_effect=mock_request_fn)
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                # Use a date range that will require multiple windows
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = "2023-01-01T00:00:00Z"
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify multiple requests were made (due to windowing)
+                self.assertGreater(len(request_calls), 0,
+                    f"Expected at least one request for {stream_name}")
+
+                # Verify requests have start_date and end_date params
+                for call in request_calls:
+                    params = call.get("params", {})
+                    self.assertIn("start_date", params,
+                        f"Request should include start_date param")
+                    self.assertIn("end_date", params,
+                        f"Request should include end_date param")
+
+    def test_sync_handles_multiple_pages_of_data(self):
+        """Verify all records across multiple window pages are synced."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Simulate multiple pages by returning different data for each call
+                call_count = [0]
+
+                def mock_request_fn(url, params=None):
+                    call_count[0] += 1
+                    # Return different records for each window
+                    if call_count[0] == 1:
+                        return {stream_name: [
+                            self._generate_stream_record(stream_name, 1, "2024-01-15T12:00:00Z"),
+                            self._generate_stream_record(stream_name, 2, "2024-02-15T12:00:00Z"),
+                        ]}
+                    elif call_count[0] == 2:
+                        return {stream_name: [
+                            self._generate_stream_record(stream_name, 3, "2024-06-15T12:00:00Z"),
+                            self._generate_stream_record(stream_name, 4, "2024-07-15T12:00:00Z"),
+                        ]}
+                    else:
+                        return {stream_name: []}
+
+                mock_request = MagicMock(side_effect=mock_request_fn)
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify records from multiple pages were collected
+                # Should have gotten records with IDs 1, 2, 3, 4
+                self.assertGreater(len(written_records), 0,
+                    "Expected records to be written from multiple pages")
+
+    def test_sync_deduplicates_records_across_windows(self):
+        """Verify that records appearing in multiple windows are deduplicated."""
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Return the same record in multiple window responses
+                duplicate_record = self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z")
+
+                call_count = [0]
+                def mock_request_fn(url, params=None):
+                    call_count[0] += 1
+                    # Return the same record in first two windows
+                    if call_count[0] <= 2:
+                        return {stream_name: [duplicate_record]}
+                    return {stream_name: []}
+
+                mock_request = MagicMock(side_effect=mock_request_fn)
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = "2023-01-01T00:00:00Z"
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Count records with ID=1
+                id_1_count = sum(1 for r in written_records if r.get("id") == 1)
+
+                # Should only write the record once despite it appearing in multiple windows
+                self.assertEqual(id_1_count, 1,
+                    f"Record with ID=1 should be written exactly once, but was written {id_1_count} times")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,157 +1,44 @@
-"""Integration tests for tap-harvest-forecast pagination with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
-from singer.catalog import Catalog
+"""Test tap can replicate multiple pages of data for streams that use pagination."""
+from tap_tester.base_suite_tests.pagination_test import PaginationTest
+from base import HarvestForecastBaseTest
 
 
-class HarvestForecastPaginationTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that the tap properly handles pagination through windowed date ranges."""
+class HarvestForecastPaginationTest(PaginationTest, HarvestForecastBaseTest):
+    """
+    Ensure tap can replicate multiple pages of data for streams that use pagination.
+    """
 
-    def test_sync_uses_date_windows(self):
-        """Verify that sync requests data in 180-day windows."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Track all request calls
-                request_calls = []
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_pagination_test"
 
-                def mock_request_fn(url, params=None):
-                    request_calls.append({"url": url, "params": params})
-                    # Return empty results
-                    return {stream_name: []}
+    def streams_to_test(self):
+        # Exclude streams that don't have enough data to test pagination
+        streams_to_exclude = {
+            'clients',
+            'people',
+            'projects',
+            'roles',
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
-                mock_request = MagicMock(side_effect=mock_request_fn)
+    def get_properties(self, original: bool = True):
+        """Configuration with reduced page_size to test pagination logic."""
+        # Start from the base test configuration to preserve required defaults.
+        properties = HarvestForecastBaseTest.get_properties(self, original=original)
 
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
+        # Override/add properties specific to pagination testing.
+        properties["start_date"] = "2025-09-01T00:00:00Z"
+        properties["page_size"] = 20
 
-                # Use a date range that will require multiple windows
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = "2023-01-01T00:00:00Z"
+        return properties
 
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )):
+    def expected_page_size(self, stream):
+        """
+        Return the expected page size for pagination testing.
 
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify multiple requests were made (due to windowing)
-                self.assertGreater(len(request_calls), 0,
-                    f"Expected at least one request for {stream_name}")
-
-                # Verify requests have start_date and end_date params
-                for call in request_calls:
-                    params = call.get("params", {})
-                    self.assertIn("start_date", params,
-                        f"Request should include start_date param")
-                    self.assertIn("end_date", params,
-                        f"Request should include end_date param")
-
-    def test_sync_handles_multiple_pages_of_data(self):
-        """Verify all records across multiple window pages are synced."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Simulate multiple pages by returning different data for each call
-                call_count = [0]
-
-                def mock_request_fn(url, params=None):
-                    call_count[0] += 1
-                    # Return different records for each window
-                    if call_count[0] == 1:
-                        return {stream_name: [
-                            self._generate_stream_record(stream_name, 1, "2024-01-15T12:00:00Z"),
-                            self._generate_stream_record(stream_name, 2, "2024-02-15T12:00:00Z"),
-                        ]}
-                    elif call_count[0] == 2:
-                        return {stream_name: [
-                            self._generate_stream_record(stream_name, 3, "2024-06-15T12:00:00Z"),
-                            self._generate_stream_record(stream_name, 4, "2024-07-15T12:00:00Z"),
-                        ]}
-                    else:
-                        return {stream_name: []}
-
-                mock_request = MagicMock(side_effect=mock_request_fn)
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', self.MOCK_CONFIG), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify records from multiple pages were collected
-                # Should have gotten records with IDs 1, 2, 3, 4
-                self.assertGreater(len(written_records), 0,
-                    "Expected records to be written from multiple pages")
-
-    def test_sync_deduplicates_records_across_windows(self):
-        """Verify that records appearing in multiple windows are deduplicated."""
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Return the same record in multiple window responses
-                duplicate_record = self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z")
-
-                call_count = [0]
-                def mock_request_fn(url, params=None):
-                    call_count[0] += 1
-                    # Return the same record in first two windows
-                    if call_count[0] <= 2:
-                        return {stream_name: [duplicate_record]}
-                    return {stream_name: []}
-
-                mock_request = MagicMock(side_effect=mock_request_fn)
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = "2023-01-01T00:00:00Z"
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Count records with ID=1
-                id_1_count = sum(1 for r in written_records if r.get("id") == 1)
-
-                # Should only write the record once despite it appearing in multiple windows
-                self.assertEqual(id_1_count, 1,
-                    f"Record with ID=1 should be written exactly once, but was written {id_1_count} times")
+        Overrides the default API_LIMIT to use the configured page_size.
+        This allows pagination testing with smaller datasets by setting
+        a lower page limit than the API default (100).
+        """
+        return self.get_properties().get("page_size", 20)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,146 +1,32 @@
-"""Integration tests for tap-harvest-forecast start_date filtering with mocked data."""
-import unittest
-from unittest.mock import patch, MagicMock
-
-try:
-    from .base import HarvestForecastBaseTest
-except ImportError:
-    from base import HarvestForecastBaseTest
-
-import tap_harvest_forecast
-from singer import utils
-from singer.catalog import Catalog
+"""Test tap respects start date for incremental streams."""
+from base import HarvestForecastBaseTest
+from tap_tester.base_suite_tests.start_date_test import StartDateTest
 
 
-class HarvestForecastStartDateTest(HarvestForecastBaseTest, unittest.TestCase):
-    """Test that start_date configuration is respected."""
+class HarvestForecastStartDateTest(StartDateTest, HarvestForecastBaseTest):
+    """Instantiate start date according to the desired data set and run the test."""
 
-    def test_records_before_start_date_are_filtered(self):
-        """Verify that records with updated_at before start_date are not synced."""
-        start_date = "2024-03-15T00:00:00Z"
+    @staticmethod
+    def name():
+        return "tap_tester_harvest_forecast_start_date_test"
 
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                # Create records: some before start_date, some after
-                records = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),  # Before
-                    self._generate_stream_record(stream_name, 2, "2024-03-14T12:00:00Z"),  # Before
-                    self._generate_stream_record(stream_name, 3, "2024-03-15T00:00:00Z"),  # At start_date
-                    self._generate_stream_record(stream_name, 4, "2024-03-20T12:00:00Z"),  # After
-                    self._generate_stream_record(stream_name, 5, "2024-03-25T12:00:00Z"),  # After
-                ]
+    def streams_to_test(self):
+        # Exclude roles stream as it's missing updated_at field in data
+        streams_to_exclude = {
+            "assignments",
+            "milestones",
+            "people",
+            "projects",
+            "roles",
+        }
+        return self.expected_stream_names().difference(streams_to_exclude)
 
-                mock_request = MagicMock(return_value={stream_name: records})
+    @property
+    def start_date_1(self):
+        """Start date before all test data."""
+        return "2026-04-01T00:00:00Z"
 
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                written_records = []
-                original_write_message = tap_harvest_forecast.singer.write_message
-                def capture_message(msg):
-                    if hasattr(msg, 'record'):
-                        written_records.append(msg.record)
-                    return original_write_message(msg)
-
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = start_date
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )), \
-                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
-
-                    tap_harvest_forecast.do_sync(catalog)
-
-                # Verify records were written
-                self.assertGreater(len(written_records), 0,
-                    f"Expected some records to be written for {stream_name}")
-
-                # Verify only records >= start_date were written
-                start_dt = utils.strptime_to_utc(start_date)
-                for record in written_records:
-                    record_dt = utils.strptime_to_utc(record["updated_at"])
-                    self.assertGreaterEqual(
-                        record_dt, start_dt,
-                        f"Record with updated_at={record['updated_at']} should not be synced "
-                        f"(before start_date={start_date})"
-                    )
-
-    def test_start_date_becomes_initial_bookmark(self):
-        """Verify that start_date is used as the initial bookmark when no state exists."""
-        start_date = "2024-03-01T00:00:00Z"
-
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                records = [
-                    self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z"),
-                ]
-
-                mock_request = MagicMock(return_value={stream_name: records})
-
-                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
-                catalog = Catalog([catalog_entry])
-
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = start_date
-
-                # Start with empty state
-                initial_state = {}
-
-                with patch.object(tap_harvest_forecast, 'request', mock_request), \
-                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', initial_state), \
-                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
-                         get_access_token=lambda: "test_token",
-                         get_account_id=lambda: "test_account"
-                     )):
-
-                    # Before sync, get_start should return start_date
-                    bookmark = tap_harvest_forecast.get_start(stream_name)
-
-                    self.assertEqual(bookmark, start_date,
-                        f"Initial bookmark should be start_date when no state exists")
-
-    def test_empty_start_date_uses_config_value(self):
-        """Verify that when STATE is empty, start_date from config is used."""
-        start_date = "2023-01-01T00:00:00Z"
-
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = start_date
-
-                with patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', {}):
-
-                    # Call get_start which should pull from config
-                    result = tap_harvest_forecast.get_start(stream_name)
-
-                    self.assertEqual(result, start_date,
-                        f"get_start should return config start_date when state is empty")
-
-    def test_bookmark_overrides_start_date(self):
-        """Verify that existing bookmark takes precedence over start_date."""
-        start_date = "2024-01-01T00:00:00Z"
-        bookmark_date = "2024-03-15T00:00:00Z"
-
-        for stream_name in self.EXPECTED_STREAMS:
-            with self.subTest(stream=stream_name):
-                config = self.MOCK_CONFIG.copy()
-                config["start_date"] = start_date
-
-                initial_state = {stream_name: bookmark_date}
-
-                with patch.object(tap_harvest_forecast, 'CONFIG', config), \
-                     patch.object(tap_harvest_forecast, 'STATE', initial_state):
-
-                    # Call get_start which should pull from state, not config
-                    result = tap_harvest_forecast.get_start(stream_name)
-
-                    self.assertEqual(result, bookmark_date,
-                        f"get_start should return bookmark from state, not config start_date")
+    @property
+    def start_date_2(self):
+        """Start date in the middle of test data range."""
+        return "2026-05-06T00:00:00Z"

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,0 +1,146 @@
+"""Integration tests for tap-harvest-forecast start_date filtering with mocked data."""
+import unittest
+from unittest.mock import patch, MagicMock
+
+try:
+    from .base import HarvestForecastBaseTest
+except ImportError:
+    from base import HarvestForecastBaseTest
+
+import tap_harvest_forecast
+from singer import utils
+from singer.catalog import Catalog
+
+
+class HarvestForecastStartDateTest(HarvestForecastBaseTest, unittest.TestCase):
+    """Test that start_date configuration is respected."""
+
+    def test_records_before_start_date_are_filtered(self):
+        """Verify that records with updated_at before start_date are not synced."""
+        start_date = "2024-03-15T00:00:00Z"
+
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                # Create records: some before start_date, some after
+                records = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-10T12:00:00Z"),  # Before
+                    self._generate_stream_record(stream_name, 2, "2024-03-14T12:00:00Z"),  # Before
+                    self._generate_stream_record(stream_name, 3, "2024-03-15T00:00:00Z"),  # At start_date
+                    self._generate_stream_record(stream_name, 4, "2024-03-20T12:00:00Z"),  # After
+                    self._generate_stream_record(stream_name, 5, "2024-03-25T12:00:00Z"),  # After
+                ]
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                written_records = []
+                original_write_message = tap_harvest_forecast.singer.write_message
+                def capture_message(msg):
+                    if hasattr(msg, 'record'):
+                        written_records.append(msg.record)
+                    return original_write_message(msg)
+
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = start_date
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )), \
+                     patch.object(tap_harvest_forecast.singer, 'write_message', side_effect=capture_message):
+
+                    tap_harvest_forecast.do_sync(catalog)
+
+                # Verify records were written
+                self.assertGreater(len(written_records), 0,
+                    f"Expected some records to be written for {stream_name}")
+
+                # Verify only records >= start_date were written
+                start_dt = utils.strptime_to_utc(start_date)
+                for record in written_records:
+                    record_dt = utils.strptime_to_utc(record["updated_at"])
+                    self.assertGreaterEqual(
+                        record_dt, start_dt,
+                        f"Record with updated_at={record['updated_at']} should not be synced "
+                        f"(before start_date={start_date})"
+                    )
+
+    def test_start_date_becomes_initial_bookmark(self):
+        """Verify that start_date is used as the initial bookmark when no state exists."""
+        start_date = "2024-03-01T00:00:00Z"
+
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                records = [
+                    self._generate_stream_record(stream_name, 1, "2024-03-15T12:00:00Z"),
+                ]
+
+                mock_request = MagicMock(return_value={stream_name: records})
+
+                catalog_entry = self.create_catalog_entry(stream_name, selected=True)
+                catalog = Catalog([catalog_entry])
+
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = start_date
+
+                # Start with empty state
+                initial_state = {}
+
+                with patch.object(tap_harvest_forecast, 'request', mock_request), \
+                     patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', initial_state), \
+                     patch.object(tap_harvest_forecast, 'AUTH', MagicMock(
+                         get_access_token=lambda: "test_token",
+                         get_account_id=lambda: "test_account"
+                     )):
+
+                    # Before sync, get_start should return start_date
+                    bookmark = tap_harvest_forecast.get_start(stream_name)
+
+                    self.assertEqual(bookmark, start_date,
+                        f"Initial bookmark should be start_date when no state exists")
+
+    def test_empty_start_date_uses_config_value(self):
+        """Verify that when STATE is empty, start_date from config is used."""
+        start_date = "2023-01-01T00:00:00Z"
+
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = start_date
+
+                with patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', {}):
+
+                    # Call get_start which should pull from config
+                    result = tap_harvest_forecast.get_start(stream_name)
+
+                    self.assertEqual(result, start_date,
+                        f"get_start should return config start_date when state is empty")
+
+    def test_bookmark_overrides_start_date(self):
+        """Verify that existing bookmark takes precedence over start_date."""
+        start_date = "2024-01-01T00:00:00Z"
+        bookmark_date = "2024-03-15T00:00:00Z"
+
+        for stream_name in self.EXPECTED_STREAMS:
+            with self.subTest(stream=stream_name):
+                config = self.MOCK_CONFIG.copy()
+                config["start_date"] = start_date
+
+                initial_state = {stream_name: bookmark_date}
+
+                with patch.object(tap_harvest_forecast, 'CONFIG', config), \
+                     patch.object(tap_harvest_forecast, 'STATE', initial_state):
+
+                    # Call get_start which should pull from state, not config
+                    result = tap_harvest_forecast.get_start(stream_name)
+
+                    self.assertEqual(result, bookmark_date,
+                        f"get_start should return bookmark from state, not config start_date")

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -1,6 +1,8 @@
 """Unit tests for tap_harvest_forecast.__init__"""
-import datetime
+import sys
 import os
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+import datetime
 import unittest
 import requests
 from unittest.mock import MagicMock, patch
@@ -42,11 +44,18 @@ class TestLoadSchema(unittest.TestCase):
                 self.assertIn("properties", schema)
 
     def test_schema_contains_id_and_updated_at(self):
-        for endpoint in thf.ENDPOINTS:
+        # roles is FULL_TABLE and has no updated_at replication key
+        incremental_endpoints = [e for e in thf.ENDPOINTS if e != "roles"]
+        for endpoint in incremental_endpoints:
             with self.subTest(endpoint=endpoint):
                 schema = thf.load_schema(endpoint)
                 self.assertIn("id", schema["properties"])
                 self.assertIn("updated_at", schema["properties"])
+
+    def test_roles_schema_has_no_updated_at(self):
+        schema = thf.load_schema("roles")
+        self.assertIn("id", schema["properties"])
+        self.assertNotIn("updated_at", schema["properties"])
 
     def test_missing_schema_raises(self):
         with self.assertRaises(Exception):
@@ -75,7 +84,7 @@ class TestGetStart(unittest.TestCase):
 
     def test_sets_state_key_when_missing(self):
         thf.get_start("clients")
-        self.assertIn("clients", thf.STATE)
+        self.assertIn("clients", thf.STATE.get("bookmarks", {}))
 
     def test_does_not_overwrite_existing_state(self):
         thf.STATE["roles"] = "2025-01-01T00:00:00Z"
@@ -334,9 +343,11 @@ class TestDoDiscover(unittest.TestCase):
         for stream in catalog_arg["streams"]:
             breadcrumb_map = {tuple(m["breadcrumb"]): m["metadata"] for m in stream["metadata"]}
             id_key = ("properties", "id")
-            updated_at_key = ("properties", "updated_at")
             self.assertEqual(breadcrumb_map[id_key]["inclusion"], "automatic")
-            self.assertEqual(breadcrumb_map[updated_at_key]["inclusion"], "automatic")
+            # roles is FULL_TABLE — no updated_at replication key
+            if stream["tap_stream_id"] != "roles":
+                updated_at_key = ("properties", "updated_at")
+                self.assertEqual(breadcrumb_map[updated_at_key]["inclusion"], "automatic")
 
 
 class TestConstants(unittest.TestCase):

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -377,7 +377,7 @@ class TestGetUrl(unittest.TestCase):
 class TestSyncEndpoint(unittest.TestCase):
     def setUp(self):
         self._state_patcher = patch.dict(thf.STATE, {}, clear=True)
-        self._config_patcher = patch.dict(thf.CONFIG, {"start_date": "2024-01-01T00:00:00Z"}, clear=True)
+        self._config_patcher = patch.dict(thf.CONFIG, {"start_date": "2024-01-01T00:00:00Z", "end_date": "2024-12-31"}, clear=True)
         self._auth_patcher = patch.object(thf, 'AUTH', _make_mock_auth())
         self._state_patcher.start()
         self._config_patcher.start()

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -1,0 +1,550 @@
+"""Unit tests for tap_harvest_forecast.__init__"""
+import datetime
+import os
+import unittest
+import requests
+from unittest.mock import MagicMock, patch
+
+import tap_harvest_forecast as thf
+
+
+def _make_mock_auth(access_token="test_token", account_id="acc_123"):
+    """Create a mock AUTH object for tests."""
+    auth = MagicMock()
+    auth.get_access_token.return_value = access_token
+    auth.get_account_id.return_value = account_id
+    return auth
+
+
+class TestGetAbsPath(unittest.TestCase):
+    def test_returns_absolute_path(self):
+        result = thf.get_abs_path("schemas/clients.json")
+        self.assertTrue(os.path.isabs(result))
+
+    def test_path_ends_with_provided_suffix(self):
+        result = thf.get_abs_path("schemas/clients.json")
+        # Normalize separators for cross-platform compatibility
+        expected_suffix = os.path.join("schemas", "clients.json")
+        self.assertTrue(result.replace("\\", "/").endswith(expected_suffix.replace("\\", "/")))
+
+    def test_different_suffixes(self):
+        r1 = thf.get_abs_path("schemas/assignments.json")
+        r2 = thf.get_abs_path("schemas/roles.json")
+        self.assertNotEqual(r1, r2)
+
+
+class TestLoadSchema(unittest.TestCase):
+    def test_loads_valid_endpoint_schemas(self):
+        for endpoint in thf.ENDPOINTS:
+            with self.subTest(endpoint=endpoint):
+                schema = thf.load_schema(endpoint)
+                self.assertIsInstance(schema, dict)
+                self.assertIn("properties", schema)
+
+    def test_schema_contains_id_and_updated_at(self):
+        for endpoint in thf.ENDPOINTS:
+            with self.subTest(endpoint=endpoint):
+                schema = thf.load_schema(endpoint)
+                self.assertIn("id", schema["properties"])
+                self.assertIn("updated_at", schema["properties"])
+
+    def test_missing_schema_raises(self):
+        with self.assertRaises(Exception):
+            thf.load_schema("nonexistent_stream")
+
+
+class TestGetStart(unittest.TestCase):
+    def setUp(self):
+        self._state_patcher = patch.dict(thf.STATE, {}, clear=True)
+        self._config_patcher = patch.dict(thf.CONFIG, {"start_date": "2024-01-01T00:00:00Z"}, clear=True)
+        self._state_patcher.start()
+        self._config_patcher.start()
+
+    def tearDown(self):
+        self._config_patcher.stop()
+        self._state_patcher.stop()
+
+    def test_returns_config_start_when_state_missing(self):
+        result = thf.get_start("assignments")
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+    def test_returns_state_value_when_present(self):
+        thf.STATE["assignments"] = "2024-06-01T00:00:00Z"
+        result = thf.get_start("assignments")
+        self.assertEqual(result, "2024-06-01T00:00:00Z")
+
+    def test_sets_state_key_when_missing(self):
+        thf.get_start("clients")
+        self.assertIn("clients", thf.STATE)
+
+    def test_does_not_overwrite_existing_state(self):
+        thf.STATE["roles"] = "2025-01-01T00:00:00Z"
+        result = thf.get_start("roles")
+        self.assertEqual(result, "2025-01-01T00:00:00Z")
+
+
+class TestGetEnd(unittest.TestCase):
+    def setUp(self):
+        self._config_patcher = patch.dict(thf.CONFIG, {}, clear=True)
+        self._config_patcher.start()
+
+    def tearDown(self):
+        self._config_patcher.stop()
+
+    def test_returns_config_end_date_when_set(self):
+        thf.CONFIG["end_date"] = "2025-12-31"
+        result = thf.get_end("assignments")
+        self.assertEqual(result, "2025-12-31")
+
+    def test_returns_future_date_when_no_end_date_configured(self):
+        result = thf.get_end("assignments")
+        # Should be roughly 2 years in the future — just assert it's a string
+        self.assertIsInstance(result, str)
+        # And that it's in the future relative to today
+        result_dt = datetime.datetime.strptime(result, thf.DATE_FORMAT)
+        self.assertGreater(result_dt, datetime.datetime.now())
+
+
+class TestAppendTimesToDates(unittest.TestCase):
+    def test_appends_time_to_date_string(self):
+        item = {"start_date": "2024-03-15", "end_date": "2024-06-30"}
+        thf.append_times_to_dates(item, ["start_date", "end_date"])
+        self.assertEqual(item["start_date"], "2024-03-15T00:00:00Z")
+        self.assertEqual(item["end_date"], "2024-06-30T00:00:00Z")
+
+    def test_skips_none_values(self):
+        item = {"start_date": None}
+        thf.append_times_to_dates(item, ["start_date"])
+        self.assertIsNone(item["start_date"])
+
+    def test_skips_missing_keys(self):
+        item = {"other_field": "value"}
+        thf.append_times_to_dates(item, ["start_date"])
+        self.assertNotIn("start_date", item)
+
+    def test_no_op_when_date_fields_is_none(self):
+        item = {"start_date": "2024-01-01"}
+        thf.append_times_to_dates(item, None)
+        self.assertEqual(item["start_date"], "2024-01-01")
+
+    def test_no_op_when_date_fields_is_empty_list(self):
+        item = {"start_date": "2024-01-01"}
+        thf.append_times_to_dates(item, [])
+        self.assertEqual(item["start_date"], "2024-01-01")
+
+
+class TestWindow(unittest.TestCase):
+    def _dt(self, s):
+        return datetime.datetime.strptime(s, "%Y-%m-%d")
+
+    def test_single_window_when_range_smaller_than_width(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2024-02-01")
+        width = datetime.timedelta(days=180)
+        windows = list(thf.window(start, end, width))
+        self.assertEqual(len(windows), 1)
+        self.assertEqual(windows[0][0], start)
+        self.assertEqual(windows[0][1], end)
+
+    def test_multiple_windows_cover_full_range(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2025-01-01")
+        width = datetime.timedelta(days=180)
+        windows = list(thf.window(start, end, width))
+        self.assertGreater(len(windows), 1)
+        # First window starts at start
+        self.assertEqual(windows[0][0], start)
+
+    def test_each_window_end_does_not_exceed_overall_end(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2025-06-01")
+        width = datetime.timedelta(days=180)
+        for ws, we in thf.window(start, end, width):
+            self.assertLessEqual(we, end)
+
+    def test_windows_are_non_overlapping(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2025-01-01")
+        width = datetime.timedelta(days=90)
+        windows = list(thf.window(start, end, width))
+        for i in range(len(windows) - 1):
+            self.assertEqual(windows[i][1], windows[i + 1][0])
+
+    def test_empty_range_returns_no_windows(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2024-01-01")  # same day
+        width = datetime.timedelta(days=180)
+        windows = list(thf.window(start, end, width))
+        self.assertEqual(len(windows), 0)
+
+    def test_exact_multiple_windows(self):
+        start = self._dt("2024-01-01")
+        end = self._dt("2024-07-01")   # 182 days
+        width = datetime.timedelta(days=91)
+        windows = list(thf.window(start, end, width))
+        self.assertEqual(len(windows), 2)
+
+
+class TestAuthClass(unittest.TestCase):
+    def _make_auth(self, access_token="test_token", expires_in=3600):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "access_token": access_token,
+            "expires_in": expires_in,
+        }
+        with patch.object(thf.Auth, "_make_refresh_token_request", return_value=mock_resp):
+            auth = thf.Auth("account_123", "client_id", "client_secret", "refresh_token")
+        return auth
+
+    def test_init_sets_access_token(self):
+        auth = self._make_auth(access_token="abc123")
+        self.assertEqual(auth._access_token, "abc123")
+
+    def test_get_access_token_returns_valid_token(self):
+        auth = self._make_auth(access_token="valid_token")
+        self.assertEqual(auth.get_access_token(), "valid_token")
+
+    def test_get_account_id_returns_account_id(self):
+        auth = self._make_auth()
+        self.assertEqual(auth.get_account_id(), "account_123")
+
+    def test_expired_token_triggers_refresh(self):
+        auth = self._make_auth()
+        # Force expiry
+        auth._expires_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        new_resp = MagicMock()
+        new_resp.json.return_value = {"access_token": "refreshed_token", "expires_in": 3600}
+        with patch.object(auth, "_make_refresh_token_request", return_value=new_resp):
+            token = auth.get_access_token()
+        self.assertEqual(token, "refreshed_token")
+
+    def test_missing_access_token_in_response_raises_key_error(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"error": "invalid_client", "error_description": "Bad credentials"}
+        with patch.object(thf.Auth, "_make_refresh_token_request", return_value=mock_resp):
+            with self.assertRaises(KeyError):
+                thf.Auth("account_123", "client_id", "client_secret", "refresh_token")
+
+
+class TestRequestFunction(unittest.TestCase):
+    def setUp(self):
+        self._config_patcher = patch.dict(thf.CONFIG, {"user_agent": "test-agent"}, clear=True)
+        self._auth_patcher = patch.object(thf, 'AUTH', _make_mock_auth())
+        self._config_patcher.start()
+        self._auth_patcher.start()
+
+    def tearDown(self):
+        self._auth_patcher.stop()
+        self._config_patcher.stop()
+
+    def test_makes_get_request_and_returns_json(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"assignments": [{"id": 1}]}
+        mock_response.raise_for_status = MagicMock()
+        with patch.object(thf.SESSION, "send", return_value=mock_response) as mock_send:
+            result = thf.request("https://api.forecastapp.com/assignments", {})
+        mock_send.assert_called_once()
+        self.assertEqual(result, {"assignments": [{"id": 1}]})
+
+    def test_raises_on_http_error(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
+        with patch.object(thf.SESSION, "send", return_value=mock_response):
+            with self.assertRaises(requests.exceptions.HTTPError):
+                thf.request("https://api.forecastapp.com/missing", {})
+
+    def test_authorization_header_set(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+        captured_requests = []
+
+        def capture(prepared_req, **kwargs):
+            captured_requests.append(prepared_req)
+            return mock_response
+
+        with patch.object(thf.SESSION, "send", side_effect=capture):
+            thf.request("https://api.forecastapp.com/people", {})
+
+        self.assertTrue(len(captured_requests) > 0)
+        headers = captured_requests[0].headers
+        self.assertIn("Authorization", headers)
+        self.assertTrue(headers["Authorization"].startswith("Bearer "))
+
+    def test_forecast_account_id_header_set(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+        captured_requests = []
+
+        def capture(prepared_req, **kwargs):
+            captured_requests.append(prepared_req)
+            return mock_response
+
+        with patch.object(thf.SESSION, "send", side_effect=capture):
+            thf.request("https://api.forecastapp.com/people", {})
+
+        headers = captured_requests[0].headers
+        self.assertIn("Forecast-Account-ID", headers)
+        self.assertEqual(headers["Forecast-Account-ID"], "acc_123")
+
+
+class TestDoDiscover(unittest.TestCase):
+    def test_outputs_valid_catalog_json(self):
+        captured = []
+        with patch("sys.stdout", new_callable=lambda: type("W", (), {"write": lambda s, x: captured.append(x), "flush": lambda s: None})()):
+            with patch("json.dump") as mock_dump:
+                thf.do_discover()
+                mock_dump.assert_called_once()
+                catalog_arg = mock_dump.call_args[0][0]
+        self.assertIn("streams", catalog_arg)
+        self.assertEqual(len(catalog_arg["streams"]), len(thf.ENDPOINTS))
+
+    def test_each_stream_has_required_keys(self):
+        with patch("json.dump") as mock_dump:
+            thf.do_discover()
+            catalog_arg = mock_dump.call_args[0][0]
+        for stream in catalog_arg["streams"]:
+            self.assertIn("stream", stream)
+            self.assertIn("tap_stream_id", stream)
+            self.assertIn("schema", stream)
+            self.assertIn("metadata", stream)
+
+    def test_stream_names_match_endpoints(self):
+        with patch("json.dump") as mock_dump:
+            thf.do_discover()
+            catalog_arg = mock_dump.call_args[0][0]
+        stream_ids = [s["tap_stream_id"] for s in catalog_arg["streams"]]
+        self.assertEqual(set(stream_ids), set(thf.ENDPOINTS))
+
+    def test_metadata_has_table_key_properties(self):
+        with patch("json.dump") as mock_dump:
+            thf.do_discover()
+            catalog_arg = mock_dump.call_args[0][0]
+        for stream in catalog_arg["streams"]:
+            breadcrumb_map = {tuple(m["breadcrumb"]): m["metadata"] for m in stream["metadata"]}
+            self.assertIn((), breadcrumb_map)
+            self.assertIn("table-key-properties", breadcrumb_map[()])
+            self.assertEqual(breadcrumb_map[()]["table-key-properties"], ["id"])
+
+    def test_id_and_updated_at_have_automatic_inclusion(self):
+        with patch("json.dump") as mock_dump:
+            thf.do_discover()
+            catalog_arg = mock_dump.call_args[0][0]
+        for stream in catalog_arg["streams"]:
+            breadcrumb_map = {tuple(m["breadcrumb"]): m["metadata"] for m in stream["metadata"]}
+            id_key = ("properties", "id")
+            updated_at_key = ("properties", "updated_at")
+            self.assertEqual(breadcrumb_map[id_key]["inclusion"], "automatic")
+            self.assertEqual(breadcrumb_map[updated_at_key]["inclusion"], "automatic")
+
+
+class TestConstants(unittest.TestCase):
+    def test_endpoints_list(self):
+        expected = ["assignments", "clients", "milestones", "people", "projects", "roles"]
+        self.assertEqual(thf.ENDPOINTS, expected)
+
+    def test_required_config_keys(self):
+        expected = ["start_date", "account_id", "client_id", "client_secret", "refresh_token"]
+        self.assertEqual(thf.REQUIRED_CONFIG_KEYS, expected)
+
+    def test_base_url(self):
+        self.assertTrue(thf.BASE_URL.startswith("https://"))
+
+    def test_date_format(self):
+        # Should be parseable by datetime
+        dt = datetime.datetime.strptime("2024-03-15", thf.DATE_FORMAT)
+        self.assertEqual(dt.day, 15)
+
+    def test_primary_key_is_id(self):
+        self.assertEqual(thf.PRIMARY_KEY, "id")
+
+    def test_replication_key_is_updated_at(self):
+        self.assertEqual(thf.REPLICATION_KEY, "updated_at")
+
+
+class TestGetUrl(unittest.TestCase):
+    def test_returns_full_url_for_endpoint(self):
+        url = thf.get_url("assignments")
+        self.assertEqual(url, "https://api.forecastapp.com/assignments")
+
+    def test_url_starts_with_base_url(self):
+        for endpoint in thf.ENDPOINTS:
+            url = thf.get_url(endpoint)
+            self.assertTrue(url.startswith(thf.BASE_URL))
+
+
+class TestSyncEndpoint(unittest.TestCase):
+    def setUp(self):
+        self._state_patcher = patch.dict(thf.STATE, {}, clear=True)
+        self._config_patcher = patch.dict(thf.CONFIG, {"start_date": "2024-01-01T00:00:00Z"}, clear=True)
+        self._auth_patcher = patch.object(thf, 'AUTH', _make_mock_auth())
+        self._state_patcher.start()
+        self._config_patcher.start()
+        self._auth_patcher.start()
+
+    def tearDown(self):
+        self._auth_patcher.stop()
+        self._config_patcher.stop()
+        self._state_patcher.stop()
+
+    def _make_catalog_entry(self, stream_id="assignments"):
+        from singer.catalog import CatalogEntry
+        schema = thf.load_schema(stream_id)
+        catalog_entry = CatalogEntry(
+            tap_stream_id=stream_id,
+            stream=stream_id,
+            schema=MagicMock(to_dict=lambda: schema),
+            metadata=[],
+        )
+        return catalog_entry, schema
+
+    def test_writes_schema_message(self):
+        catalog_entry, schema = self._make_catalog_entry("assignments")
+        mdata = {}
+
+        sample_record = {
+            "id": 1,
+            "updated_at": "2024-03-01T12:00:00Z",
+            "start_date": "2024-03-01",
+            "end_date": "2024-03-31",
+        }
+        mock_response = {"assignments": [sample_record]}
+
+        with patch("singer.write_schema") as mock_ws, \
+             patch("singer.write_message") as mock_wm, \
+             patch("singer.write_state") as mock_wst, \
+             patch.object(thf, "request", return_value=mock_response):
+            thf.sync_endpoint(catalog_entry, schema, mdata)
+
+        mock_ws.assert_called_once_with(
+            "assignments", schema, ["id"], bookmark_properties=["updated_at"]
+        )
+
+    def test_writes_records_for_each_row(self):
+        catalog_entry, schema = self._make_catalog_entry("assignments")
+        mdata = {}
+
+        records = [
+            {"id": 1, "updated_at": "2024-03-01T12:00:00Z"},
+            {"id": 2, "updated_at": "2024-03-02T12:00:00Z"},
+        ]
+        mock_response = {"assignments": records}
+
+        with patch("singer.write_schema"), \
+             patch("singer.write_message") as mock_wm, \
+             patch("singer.write_state"), \
+             patch.object(thf, "request", return_value=mock_response):
+            thf.sync_endpoint(catalog_entry, schema, mdata)
+
+        # write_message called once per unique record (spanning all windows)
+        self.assertGreaterEqual(mock_wm.call_count, len(records))
+
+    def test_deduplicates_records_by_id(self):
+        catalog_entry, schema = self._make_catalog_entry("assignments")
+        mdata = {}
+
+        # Same record appears in multiple windows
+        record = {"id": 1, "updated_at": "2024-03-01T12:00:00Z"}
+        mock_response = {"assignments": [record]}
+
+        written_records = []
+        with patch("singer.write_schema"), \
+             patch("singer.write_message", side_effect=lambda m: written_records.append(m)), \
+             patch("singer.write_state"), \
+             patch.object(thf, "request", return_value=mock_response):
+            thf.sync_endpoint(catalog_entry, schema, mdata)
+
+        ids = [m.record["id"] for m in written_records]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_writes_state_after_sync(self):
+        catalog_entry, schema = self._make_catalog_entry("assignments")
+        mdata = {}
+        mock_response = {"assignments": []}
+
+        with patch("singer.write_schema"), \
+             patch("singer.write_message"), \
+             patch("singer.write_state") as mock_wst, \
+             patch.object(thf, "request", return_value=mock_response):
+            thf.sync_endpoint(catalog_entry, schema, mdata)
+
+        mock_wst.assert_called_once()
+
+
+class TestDoSync(unittest.TestCase):
+    def test_calls_sync_endpoint_for_selected_streams(self):
+        mock_stream = MagicMock()
+        mock_stream.tap_stream_id = "assignments"
+        mock_stream.schema.to_dict.return_value = thf.load_schema("assignments")
+        mock_stream.metadata = []
+
+        from singer import metadata as singer_metadata
+        mdata = singer_metadata.new()
+        singer_metadata.write(mdata, (), "selected", True)
+        mock_stream.metadata = singer_metadata.to_list(mdata)
+
+        mock_catalog = MagicMock()
+        mock_catalog.streams = [mock_stream]
+
+        with patch.object(thf, "sync_endpoint") as mock_se:
+            thf.do_sync(mock_catalog)
+
+        mock_se.assert_called_once()
+
+    def test_skips_unselected_streams(self):
+        mock_stream = MagicMock()
+        mock_stream.tap_stream_id = "clients"
+        mock_stream.metadata = []  # no 'selected' metadata → not selected
+
+        mock_catalog = MagicMock()
+        mock_catalog.streams = [mock_stream]
+
+        with patch.object(thf, "sync_endpoint") as mock_se:
+            thf.do_sync(mock_catalog)
+
+        mock_se.assert_not_called()
+
+
+class TestMainImpl(unittest.TestCase):
+    def _make_args(self, discover=False, catalog=None, state=None):
+        args = MagicMock()
+        args.config = {
+            "start_date": "2024-01-01T00:00:00Z",
+            "account_id": "acc",
+            "client_id": "cid",
+            "client_secret": "csec",
+            "refresh_token": "rtok",
+        }
+        args.state = state or {}
+        args.discover = discover
+        args.catalog = catalog
+        return args
+
+    def _mock_auth(self):
+        mock_auth = MagicMock()
+        mock_auth.get_access_token.return_value = "tok"
+        mock_auth.get_account_id.return_value = "acc"
+        return mock_auth
+
+    def test_discover_mode_calls_do_discover(self):
+        args = self._make_args(discover=True)
+        with patch("singer.utils.parse_args", return_value=args), \
+             patch.object(thf, "Auth", return_value=self._mock_auth()), \
+             patch.object(thf, "do_discover") as mock_dd:
+            thf.main_impl()
+        mock_dd.assert_called_once()
+
+    def test_sync_mode_calls_do_sync(self):
+        mock_catalog = MagicMock()
+        args = self._make_args(catalog=mock_catalog)
+        with patch("singer.utils.parse_args", return_value=args), \
+             patch.object(thf, "Auth", return_value=self._mock_auth()), \
+             patch.object(thf, "do_sync") as mock_ds:
+            thf.main_impl()
+        mock_ds.assert_called_once_with(mock_catalog)
+
+    def test_main_catches_exception_and_re_raises(self):
+        with patch.object(thf, "main_impl", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                thf.main()


### PR DESCRIPTION
# Description of change
Adds a comprehensive Python unittest suite around `tap_harvest_forecast` behavior (discovery, sync/windowing, bookmarks/state) and updates dependencies/CI to run the tests while also adjusting several JSON schemas to allow nullable arrays/objects.

Jira Ticket: [SAC-28723](https://qlik-dev.atlassian.net/browse/SAC-28723)

**Changes:**
- Add new unit + “integration-style” tests covering discovery output, pagination/windowing, bookmarking, interrupted sync resumption, and start_date filtering.
- Update multiple stream schemas to allow `null` for fields that are sometimes returned as null (arrays/objects).
- Bump library pins and update CircleCI to run `unittest` and use Python 3.12.


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
