### PR TITLE
Exclude unauthorized streams in catalog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,184 @@
+﻿# Instructions for Building a Singer Tap/Target
+
+This document provides guidance for implementing a high-quality Singer Tap (or Target) in compliance with the Singer specification and community best practices. Use it in conjunction with GitHub Copilot or your preferred IDE.
+
+---
+
+## 1. Rate Limiting
+
+- Respect API rate limits (e.g., daily quotas or per-second limits).
+- For short-term rate limits, detect HTTP 429 or similar errors and implement retries with sleep/delay.
+- Use Singer’s built-in rate-limiting utilities where available.
+
+
+## 2. Memory Efficiency
+
+- Minimize RAM usage by streaming data.
+Example: Use generators or iterators instead of loading entire datasets into memory.
+
+
+## 3. Consistent Date Handling
+
+- Use RFC 3339 format (including time zone offset). UTC (Z) is preferred.
+Examples:
+Good: 2017-01-01T00:00:00Z, 2017-01-01T00:00:00-05:00
+Bad: 2017-01-01 00:00:00
+Use pytz for timezone-aware conversions.
+
+
+## 4. Logging & Exception Handling
+
+- Log every API request (URL + parameters), omitting sensitive info (e.g., API keys).
+- Log progress updates (e.g., “Starting stream X”).
+- On API errors, log status code and response body.
+
+For fatal errors:
+- Log at CRITICAL or FATAL level.
+- Exit with non-zero status.
+- Omit stack trace for known, user-triggered conditions.
+- Include full trace for unexpected exceptions.
+- For recoverable errors, implement retries with exponential backoff (e.g., using the backoff library).
+
+
+## 5. Module Structure
+
+- Organize code into a proper Python module (directory with __init__.py), not a single script file.
+
+
+## 6. Schema Management
+
+- For static schemas, store them as .json files in a schemas/ directory—not as inline Python dicts.
+Prefer explicit schemas:
+- Avoid additionalProperties: true or vague typing.
+- Use clear field names and types.
+- Set additionalProperties: false when schemas must be strict.
+- Be cautious when tightening schemas in new versions—it may require a major version bump per semantic versioning.
+
+
+## 7. JSON Schema Guidelines
+
+- All files under schemas/*.json must follow the JSON Schema standard.
+- Any fields named created_time, modified_time, ending in _time or ending in _date must use the date-time format.
+- Any fields look like date-time field, give suggestion to validate the fields should have date-time format.
+- Avoid using additionalProperties at the root level. It's allowed in nested fields only.
+
+Example:
+{
+  "type": "object",
+  "properties": {
+    "created_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "last_access_time": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    }
+  }
+}
+
+
+## 8. Validating Bookmarking
+
+We use the singer.bookmarks module to read from and write to the bookmark state file.
+To ensure correctness, always validate the structure of the bookmark state before processing or committing any changes.
+- In abstract.py, we use get_bookmark() and write_bookmark() to manage bookmarks for streams.
+- The write_bookmark() function overrides the one from the singer module to apply custom behavior.
+- Always confirm that the state structure matches the expected format before writing.
+
+Format Example:
+{
+  "bookmarks": {
+    "stream_name": {
+      "replication_key": "2024-01-01T00:00:00Z"
+    }
+  }
+}
+
+
+Optional validation function:
+def is_valid_bookmark_state(state):
+    return isinstance(state, dict) and \
+           "bookmarks" in state and \
+           isinstance(state["bookmarks"], dict)
+
+
+## 9. Code Quality
+
+- Use pylint and aim for zero error-level messages.
+- CI pipelines (e.g., CircleCI) should enforce linting.
+- Fix or explicitly disable warnings when appropriate.
+
+
+## 10. Loop Safety
+
+- **Avoid `while True` loops.** Use explicit conditions instead (e.g., `while has_more_pages`).
+- Every loop must have a clear exit condition that will eventually be satisfied.
+- For pagination loops, ensure there's a termination condition (e.g., no next page, empty results, max iterations).
+- Add safeguards like maximum iteration counts or timeouts for loops that depend on external API responses.
+
+Good example (explicit condition):
+```python
+max_pages = 1000
+current_page = 1
+has_more_pages = True
+
+while has_more_pages and current_page <= max_pages:
+    response = fetch_page(current_page)
+    if not response or not response.get('data'):
+        has_more_pages = False
+        break
+
+    process_data(response['data'])
+
+    next_page = response.get('next_page')
+    if not next_page:
+        has_more_pages = False
+    else:
+        current_page += 1
+```
+
+Bad example (using while True):
+```python
+while True:
+    response = fetch_page()
+    if not response:
+        break  # Avoid this pattern
+    process_data(response)
+```
+
+
+## 11. Record Completeness
+
+- **Never skip records during sync unless absolutely necessary.**
+- If a record encounters an error during transformation or validation, log the error with full context but do not silently skip it.
+- Only skip records if:
+  - They fail schema validation and cannot be processed (log as WARNING or ERROR).
+  - They are explicitly filtered by business logic (e.g., replication key filtering).
+- **Never use `continue` to skip records on errors without logging.**
+
+Good example (log and handle errors):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+        counter.increment()
+    except Exception as e:
+        LOGGER.error(f"Failed to transform record {record.get('id')}: {e}")
+        # Re-raise or handle based on severity
+        raise
+```
+
+Bad example (silently skipping records):
+```python
+for record in get_records():
+    try:
+        transformed = transformer.transform(record, schema, metadata)
+        write_record(stream_name, transformed)
+    except Exception:
+        continue  # Silently skips - BAD!
+```
+
+- For incremental streams, ensure bookmark filtering logic is correct to avoid data loss.
+- If a record must be skipped, document why in the code and log it clearly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+  * Streams the credentials cannot access (403 Forbidden) are now excluded from the catalog during discovery instead of raising an error [#33](https://github.com/singer-io/tap-harvest-forecast/pull/33)
+  * If no streams are accessible, discovery raises a clear `ForecastForbiddenError` rather than producing an empty catalog
+  * Added unit tests for `check_stream_access`, `_get_accessible_endpoints`, and access-aware discovery
+
 ## 1.2.0
   * Upgrade `singer-python`, `requests` and `backoff` to latest version
   * Add unit tests and mocked integration tests [#32](https://github.com/singer-io/tap-harvest-forecast/pull/32)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## 1.2.1
-  * Streams the credentials cannot access (403 Forbidden) are now excluded from the catalog during discovery instead of raising an error [#35](https://github.com/singer-io/tap-harvest-forecast/pull/35)
-  * If no streams are accessible, discovery raises a clear `ForecastForbiddenError` rather than producing an empty catalog
-  * Added unit tests for `check_stream_access`, `_get_accessible_endpoints`, and access-aware discovery
+## 1.3.0
+  * Exclude 403-forbidden streams from discovery instead of failing [#35](https://github.com/singer-io/tap-harvest-forecast/pull/35)
+  * Raise ForecastForbiddenError when no streams are accessible
+  * Added unit tests for access-aware discovery helpers
 
 ## 1.2.0
   * Upgrade `singer-python`, `requests` and `backoff` to latest version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.2.1
-  * Streams the credentials cannot access (403 Forbidden) are now excluded from the catalog during discovery instead of raising an error [#33](https://github.com/singer-io/tap-harvest-forecast/pull/33)
+  * Streams the credentials cannot access (403 Forbidden) are now excluded from the catalog during discovery instead of raising an error [#35](https://github.com/singer-io/tap-harvest-forecast/pull/35)
   * If no streams are accessible, discovery raises a clear `ForecastForbiddenError` rather than producing an empty catalog
   * Added unit tests for `check_stream_access`, `_get_accessible_endpoints`, and access-aware discovery
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 setup(name='tap-harvest-forecast',
-      version="1.2.1",
+      version="1.3.0",
       description='Singer.io tap for extracting data from the Harvest Forecast api',
       author='Robert Benjamin',
       url='https://github.com/singer-io/tap-harvest-forecast',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 setup(name='tap-harvest-forecast',
-      version="1.2.0",
+      version="1.2.1",
       description='Singer.io tap for extracting data from the Harvest Forecast api',
       author='Robert Benjamin',
       url='https://github.com/singer-io/tap-harvest-forecast',

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -154,25 +154,26 @@ def _get_accessible_endpoints(endpoints):
     Raises ForecastForbiddenError when every endpoint is inaccessible so that
     discovery fails fast rather than producing an empty catalog.
     """
-    accessible = []
-    inaccessible = []
+    accessible_endpoints = []
+    inaccessible_endpoints = []
     for ep in endpoints:
-        (accessible if check_stream_access(ep) else inaccessible).append(ep)
+        (accessible_endpoints if check_stream_access(ep) else inaccessible_endpoints).append(ep)
 
-    if inaccessible:
-        if not accessible:
-            raise ForecastForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
-                "'read' access to any of the streams supported by the tap. "
-                "Data collection cannot be initiated due to lack of permissions."
-            )
+    if not accessible_endpoints:
+        raise ForecastForbiddenError(
+            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+            "'read' access to any of the streams supported by the tap. "
+            "Data collection cannot be initiated due to lack of permissions."
+        )
+
+    if inaccessible_endpoints:
         LOGGER.warning(
             "The account credentials supplied do not have 'read' access to the "
             "following stream(s): %s. These streams have been excluded from the catalog.",
-            ", ".join(inaccessible),
+            ", ".join(inaccessible_endpoints),
         )
 
-    return accessible
+    return accessible_endpoints
 
 
 @backoff.on_exception(

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -161,9 +161,7 @@ def _get_accessible_endpoints(endpoints):
 
     if not accessible_endpoints:
         raise ForecastForbiddenError(
-            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
-            "'read' access to any of the streams supported by the tap. "
-            "Data collection cannot be initiated due to lack of permissions."
+            "The account credentials do not have access to any of the supported streams."
         )
 
     if inaccessible_endpoints:

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -14,6 +14,12 @@ import time
 
 LOGGER = singer.get_logger()
 SESSION = requests.Session()
+
+
+class ForecastForbiddenError(Exception):
+    """Raised when the API returns 403 Forbidden for a stream endpoint."""
+
+
 REQUIRED_CONFIG_KEYS = [
     "start_date",
     "account_id",
@@ -118,6 +124,53 @@ def get_end(key):
 
 def get_url(endpoint):
     return BASE_URL + endpoint
+
+
+def check_stream_access(endpoint):
+    """Probe an endpoint with a minimal date-window request to verify read access.
+
+    Returns True if the credentials have access, False if the API responds with
+    403 Forbidden.  All other HTTP errors are re-raised.
+    """
+    today = utils.now().strftime(DATE_FORMAT)
+    url = get_url(endpoint)
+    try:
+        request(url, params={"start_date": today, "end_date": today})
+        return True
+    except requests.exceptions.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 403:
+            LOGGER.warning(
+                "Stream '%s' is not accessible with the provided credentials (403 Forbidden). "
+                "Excluding from catalog.",
+                endpoint,
+            )
+            return False
+        raise
+
+
+def _get_accessible_endpoints(endpoints):
+    """Return the subset of endpoints the credentials can read.
+
+    Raises ForecastForbiddenError when every endpoint is inaccessible so that
+    discovery fails fast rather than producing an empty catalog.
+    """
+    inaccessible = [ep for ep in endpoints if not check_stream_access(ep)]
+
+    if inaccessible:
+        if len(inaccessible) == len(endpoints):
+            raise ForecastForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+                "'read' access to any of the streams supported by the tap. "
+                "Data collection cannot be initiated due to lack of permissions."
+            )
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the "
+            "following stream(s): %s. These streams have been excluded from the catalog.",
+            ", ".join(inaccessible),
+        )
+
+    return [ep for ep in endpoints if ep not in inaccessible]
+
 
 @backoff.on_exception(
     backoff.expo,
@@ -235,8 +288,9 @@ def do_sync(catalog):
     LOGGER.info("Sync complete")
 
 def do_discover():
+    accessible_endpoints = _get_accessible_endpoints(ENDPOINTS)
     streams = []
-    for endpoint in ENDPOINTS:
+    for endpoint in accessible_endpoints:
         schema = load_schema(endpoint)
 
         mdata = metadata.new()

--- a/tap_harvest_forecast/__init__.py
+++ b/tap_harvest_forecast/__init__.py
@@ -154,10 +154,13 @@ def _get_accessible_endpoints(endpoints):
     Raises ForecastForbiddenError when every endpoint is inaccessible so that
     discovery fails fast rather than producing an empty catalog.
     """
-    inaccessible = [ep for ep in endpoints if not check_stream_access(ep)]
+    accessible = []
+    inaccessible = []
+    for ep in endpoints:
+        (accessible if check_stream_access(ep) else inaccessible).append(ep)
 
     if inaccessible:
-        if len(inaccessible) == len(endpoints):
+        if not accessible:
             raise ForecastForbiddenError(
                 "HTTP-error-code: 403, Error: The account credentials supplied do not have "
                 "'read' access to any of the streams supported by the tap. "
@@ -169,7 +172,7 @@ def _get_accessible_endpoints(endpoints):
             ", ".join(inaccessible),
         )
 
-    return [ep for ep in endpoints if ep not in inaccessible]
+    return accessible
 
 
 @backoff.on_exception(

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -1,6 +1,7 @@
 """Unit tests for tap_harvest_forecast.__init__"""
 import sys
 import os
+import io
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 import datetime
 import json
@@ -585,7 +586,7 @@ class TestCheckStreamAccess(unittest.TestCase):
     def tearDown(self):
         self._auth_patcher.stop()
 
-    def _make_403_error(self, url="https://api.forecastapp.com/assignments"):
+    def _make_403_error(self):
         resp = MagicMock()
         resp.status_code = 403
         exc = requests.exceptions.HTTPError(response=resp)
@@ -698,25 +699,21 @@ class TestDoDiscoverAccessChecks(unittest.TestCase):
 
     def test_discover_includes_only_accessible_streams(self):
         accessible = ["assignments", "clients"]
+        captured = io.StringIO()
         with patch.object(thf, "_get_accessible_endpoints", return_value=accessible), \
-             patch("sys.stdout"):
-            import io
-            captured = io.StringIO()
-            with patch("sys.stdout", captured):
-                thf.do_discover()
-            catalog = json.loads(captured.getvalue())
+             patch("sys.stdout", captured):
+            thf.do_discover()
+        catalog = json.loads(captured.getvalue())
 
         stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
         self.assertEqual(set(stream_ids), {"assignments", "clients"})
 
     def test_discover_with_all_accessible_streams(self):
+        captured = io.StringIO()
         with patch.object(thf, "_get_accessible_endpoints", return_value=thf.ENDPOINTS), \
-             patch("sys.stdout"):
-            import io
-            captured = io.StringIO()
-            with patch("sys.stdout", captured):
-                thf.do_discover()
-            catalog = json.loads(captured.getvalue())
+             patch("sys.stdout", captured):
+            thf.do_discover()
+        catalog = json.loads(captured.getvalue())
 
         stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
         self.assertEqual(set(stream_ids), set(thf.ENDPOINTS))

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -3,6 +3,7 @@ import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
 import datetime
+import json
 import unittest
 import requests
 from unittest.mock import MagicMock, patch
@@ -299,6 +300,15 @@ class TestRequestFunction(unittest.TestCase):
 
 
 class TestDoDiscover(unittest.TestCase):
+    def setUp(self):
+        self._access_patcher = patch.object(
+            thf, "_get_accessible_endpoints", return_value=thf.ENDPOINTS
+        )
+        self._access_patcher.start()
+
+    def tearDown(self):
+        self._access_patcher.stop()
+
     def test_outputs_valid_catalog_json(self):
         captured = []
         with patch("sys.stdout", new_callable=lambda: type("W", (), {"write": lambda s, x: captured.append(x), "flush": lambda s: None})()):
@@ -559,3 +569,160 @@ class TestMainImpl(unittest.TestCase):
         with patch.object(thf, "main_impl", side_effect=RuntimeError("boom")):
             with self.assertRaises(RuntimeError):
                 thf.main()
+
+
+# ---------------------------------------------------------------------------
+# Tests for check_stream_access
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Unit tests for check_stream_access()."""
+
+    def setUp(self):
+        self._auth_patcher = patch.object(thf, "AUTH", _make_mock_auth())
+        self._auth_patcher.start()
+
+    def tearDown(self):
+        self._auth_patcher.stop()
+
+    def _make_403_error(self, url="https://api.forecastapp.com/assignments"):
+        resp = MagicMock()
+        resp.status_code = 403
+        exc = requests.exceptions.HTTPError(response=resp)
+        return exc
+
+    def test_returns_true_when_request_succeeds(self):
+        with patch.object(thf, "request", return_value={"assignments": []}):
+            result = thf.check_stream_access("assignments")
+        self.assertTrue(result)
+
+    def test_returns_false_on_403(self):
+        with patch.object(thf, "request", side_effect=self._make_403_error()):
+            result = thf.check_stream_access("assignments")
+        self.assertFalse(result)
+
+    def test_reraises_non_403_http_error(self):
+        resp = MagicMock()
+        resp.status_code = 500
+        exc = requests.exceptions.HTTPError(response=resp)
+        with patch.object(thf, "request", side_effect=exc):
+            with self.assertRaises(requests.exceptions.HTTPError):
+                thf.check_stream_access("assignments")
+
+    def test_reraises_connection_error(self):
+        with patch.object(thf, "request", side_effect=requests.exceptions.ConnectionError("timeout")):
+            with self.assertRaises(requests.exceptions.ConnectionError):
+                thf.check_stream_access("assignments")
+
+    def test_uses_today_as_date_window(self):
+        """check_stream_access must pass start_date and end_date params."""
+        captured = {}
+
+        def fake_request(url, params=None):
+            captured["params"] = params
+            return {"assignments": []}
+
+        with patch.object(thf, "request", side_effect=fake_request):
+            thf.check_stream_access("assignments")
+
+        self.assertIn("start_date", captured["params"])
+        self.assertIn("end_date", captured["params"])
+        self.assertEqual(captured["params"]["start_date"], captured["params"]["end_date"])
+
+
+# ---------------------------------------------------------------------------
+# Tests for _get_accessible_endpoints
+# ---------------------------------------------------------------------------
+
+class TestGetAccessibleEndpoints(unittest.TestCase):
+    """Unit tests for _get_accessible_endpoints()."""
+
+    ALL_ENDPOINTS = ["assignments", "clients", "milestones", "people", "projects", "roles"]
+
+    def test_returns_all_when_all_accessible(self):
+        with patch.object(thf, "check_stream_access", return_value=True):
+            result = thf._get_accessible_endpoints(self.ALL_ENDPOINTS)
+        self.assertEqual(result, self.ALL_ENDPOINTS)
+
+    def test_excludes_inaccessible_streams(self):
+        def access_side_effect(ep):
+            return ep != "roles"
+
+        with patch.object(thf, "check_stream_access", side_effect=access_side_effect):
+            result = thf._get_accessible_endpoints(self.ALL_ENDPOINTS)
+
+        self.assertNotIn("roles", result)
+        self.assertIn("assignments", result)
+
+    def test_raises_when_all_inaccessible(self):
+        with patch.object(thf, "check_stream_access", return_value=False):
+            with self.assertRaises(thf.ForecastForbiddenError) as ctx:
+                thf._get_accessible_endpoints(self.ALL_ENDPOINTS)
+        self.assertIn("403", str(ctx.exception))
+
+    def test_partial_access_does_not_raise(self):
+        def access_side_effect(ep):
+            return ep in ["assignments", "clients"]
+
+        with patch.object(thf, "check_stream_access", side_effect=access_side_effect):
+            result = thf._get_accessible_endpoints(self.ALL_ENDPOINTS)
+
+        self.assertEqual(set(result), {"assignments", "clients"})
+
+    def test_preserves_endpoint_order(self):
+        endpoints = ["roles", "assignments", "clients"]
+
+        def access_side_effect(ep):
+            return ep != "roles"
+
+        with patch.object(thf, "check_stream_access", side_effect=access_side_effect):
+            result = thf._get_accessible_endpoints(endpoints)
+
+        self.assertEqual(result, ["assignments", "clients"])
+
+
+# ---------------------------------------------------------------------------
+# Tests for do_discover with access checks
+# ---------------------------------------------------------------------------
+
+
+class TestDoDiscoverAccessChecks(unittest.TestCase):
+    """Verify do_discover() honours _get_accessible_endpoints()."""
+
+    def setUp(self):
+        self._auth_patcher = patch.object(thf, "AUTH", _make_mock_auth())
+        self._auth_patcher.start()
+
+    def tearDown(self):
+        self._auth_patcher.stop()
+
+    def test_discover_includes_only_accessible_streams(self):
+        accessible = ["assignments", "clients"]
+        with patch.object(thf, "_get_accessible_endpoints", return_value=accessible), \
+             patch("sys.stdout"):
+            import io
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                thf.do_discover()
+            catalog = json.loads(captured.getvalue())
+
+        stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
+        self.assertEqual(set(stream_ids), {"assignments", "clients"})
+
+    def test_discover_with_all_accessible_streams(self):
+        with patch.object(thf, "_get_accessible_endpoints", return_value=thf.ENDPOINTS), \
+             patch("sys.stdout"):
+            import io
+            captured = io.StringIO()
+            with patch("sys.stdout", captured):
+                thf.do_discover()
+            catalog = json.loads(captured.getvalue())
+
+        stream_ids = [s["tap_stream_id"] for s in catalog["streams"]]
+        self.assertEqual(set(stream_ids), set(thf.ENDPOINTS))
+
+    def test_discover_raises_when_no_streams_accessible(self):
+        with patch.object(thf, "_get_accessible_endpoints",
+                          side_effect=thf.ForecastForbiddenError("no access")):
+            with self.assertRaises(thf.ForecastForbiddenError):
+                thf.do_discover()

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -659,7 +659,7 @@ class TestGetAccessibleEndpoints(unittest.TestCase):
         with patch.object(thf, "check_stream_access", return_value=False):
             with self.assertRaises(thf.ForecastForbiddenError) as ctx:
                 thf._get_accessible_endpoints(self.ALL_ENDPOINTS)
-        self.assertIn("403", str(ctx.exception))
+        self.assertIn("supported streams", str(ctx.exception))
 
     def test_partial_access_does_not_raise(self):
         def access_side_effect(ep):


### PR DESCRIPTION
# Description of change

This PR updates discovery behavior for the Harvest Forecast tap so that stream endpoints returning **403 Forbidden** are excluded from the generated Singer catalog, rather than causing discovery to fail (unless *all* streams are forbidden).

**Changes:**
- Added `check_stream_access(endpoint)` — probes a stream endpoint via a minimal date-window GET request and returns `True`/`False` on 403 Forbidden
- Added `_get_accessible_endpoints(endpoints)` — iterates all endpoints, collects accessible ones, logs a warning for each excluded stream, and raises `ForecastForbiddenError` if none are accessible
- Updated `do_discover()` to call `_get_accessible_endpoints()` and only include authorized endpoints in the generated catalog
- Added unit tests covering access probing, endpoint filtering, partial exclusion, and the all-streams-blocked error case; bumped version to 1.3.0 and updated changelog

Jira: [SAC-30967](https://qlik-dev.atlassian.net/browse/SAC-30967)

# Manual QA steps
- [x] Discovery: `tap-harvest-forecast --config config.json --discover` — verify catalog contains only accessible streams
- [x] Discovery with blocked credentials — verify `ForecastForbiddenError` is raised when no streams are accessible
- [x] Sync: `tap-harvest-forecast --config config.json --catalog catalog.json --state state.json` — verify sync runs normally
- [x] Unit Tests: `pytest tests/unittests/ tests/mock_integration/` — all tests pass
- [x] Integration test: Running
 
# Risks
- Discovery now makes one extra API call per stream; adds ~6 lightweight requests during `--discover`
- Taps with fully restricted credentials will now fail fast at discovery instead of silently at sync time (intentional)
 
# Rollback steps
 - Revert this branch


#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
